### PR TITLE
@seealso link to str_subset() from str_detect()

### DIFF
--- a/R/detect.r
+++ b/R/detect.r
@@ -19,7 +19,9 @@
 #'   \code{\link{boundary}()}. An empty pattern, "", is equivalent to
 #'   \code{boundary("character")}.
 #' @return A logical vector.
-#' @seealso \code{\link[stringi]{stri_detect}} which this function wraps
+#' @seealso \code{\link[stringi]{stri_detect}} which this function wraps,
+#'   \code{\link{str_subset}} for a convenient wrapper around 
+#'   \code{x[str_detect(x, pattern)]}
 #' @export
 #' @examples
 #' fruit <- c("apple", "banana", "pear", "pinapple")


### PR DESCRIPTION
Hello,

Minor doc improvement. I always forget what `str_subset()` is called, and end up looking at the docs for `str_detect()` first when I want it, then when it's not there I end up clicking randomly through all the `str_*` functions till I find the one I'm looking for.