### PR TITLE
Feature request: vectorise str_interp in interpolated expressions

### DIFF
--- a/R/interp.R
+++ b/R/interp.R
@@ -69,14 +69,15 @@ str_interp <- function(string, env = parent.frame()) {
     # check that lengths are valid
     lengths <- sapply(replacements, length)
     max_length <- max(lengths)
-    if (!all(lengths %in% c(1, max_length))) {
+    if (!all(lengths == 1L | lengths == max_length)) {
       stop("Not all expressions in interpolated strings ",
            "have same length or length 1.")
     }
 
     # extend length 1 vectors
-    replacements <- lapply(replacements,
-                           function(x) rep(x, length.out = max_length))
+    to_recycle <- lengths == 1L
+    replacements[to_recycle] <- lapply(replacements[to_recycle],
+                                       function(x) rep.int(x, max_length))
 
     n_matches <- length(matches$matches)
     replacements <- matrix(unlist(replacements), ncol = n_matches)

--- a/R/interp.R
+++ b/R/interp.R
@@ -79,6 +79,7 @@ str_interp <- function(string, env = parent.frame()) {
     replacements[to_recycle] <- lapply(replacements[to_recycle],
                                        function(x) rep.int(x, max_length))
 
+    # do the replacements
     n_matches <- length(matches$matches)
     replacements <- matrix(unlist(replacements), ncol = n_matches)
 

--- a/R/interp.R
+++ b/R/interp.R
@@ -45,6 +45,12 @@
 #'   "This particular line is so long that it is hard to write ",
 #'   "without breaking the ${max_char}-char barrier!"
 #' ))
+#'
+#' # Interpolated expressions are cycled over:
+#' student <- "Bob"
+#' test <- c(1, 2)
+#' grade <- c(1.3, 2.7)
+#' str_interp("${student} got a ${grade} in test ${test}.")
 str_interp <- function(string, env = parent.frame()) {
   if (!is.character(string)) {
     stop("string argument is not character.", call. = FALSE)
@@ -58,11 +64,30 @@ str_interp <- function(string, env = parent.frame()) {
   if (matches$indices[1] <= 0) {
     string
   } else {
-    # Evaluate them to get the replacement strings.
-    replacements <- eval_interp_matches(matches$matches, env)
+    replacements <- eval_interp_matches(matches$matches, env, FALSE)
 
-    # Replace the expressions by their values and return.
-    `regmatches<-`(string, list(matches$indices), FALSE, list(replacements))
+    # check that lengths are valid
+    lengths <- sapply(replacements, length)
+    max_length <- max(lengths)
+    if (!all(lengths %in% c(1, max_length))) {
+      stop("Not all expressions in interpolated strings ",
+           "have same length or length 1.")
+    }
+
+    # extend length 1 vectors
+    replacements <- lapply(replacements,
+                           function(x) rep(x, length.out = max_length))
+
+    n_matches <- length(matches$matches)
+    replacements <- matrix(unlist(replacements), ncol = n_matches)
+
+    sapply(
+      1:max_length,
+      function(row) {
+        `regmatches<-`(string, list(matches$indices), FALSE,
+                       list(replacements[row, ]))
+      }
+    )
   }
 }
 
@@ -128,7 +153,7 @@ interp_placeholders <- function(string) {
 #'
 #' @noRd
 #' @author Stefan Milton Bache
-eval_interp_matches <- function(matches, env) {
+eval_interp_matches <- function(matches, env, SIMPLIFY = TRUE) {
   # Extract expressions from the matches
   expressions <- extract_expressions(matches)
 
@@ -140,7 +165,7 @@ eval_interp_matches <- function(matches, env) {
   formats <- extract_formats(matches)
 
   # Format the values and return.
-  mapply(sprintf, formats, values)
+  mapply(sprintf, formats, values, SIMPLIFY = SIMPLIFY)
 }
 
 #' Extract Expression Objects from String Interpolation Matches

--- a/man/str_interp.Rd
+++ b/man/str_interp.Rd
@@ -55,6 +55,12 @@ str_interp(c(
   "This particular line is so long that it is hard to write ",
   "without breaking the ${max_char}-char barrier!"
 ))
+
+# Interpolated expressions are cycled over:
+student <- "Bob"
+test <- c(1, 2)
+grade <- c(1.3, 2.7)
+str_interp("${student} got a ${grade} in test ${test}.")
 }
 \author{
 Stefan Milton Bache

--- a/tests/testthat/test-interp.r
+++ b/tests/testthat/test-interp.r
@@ -16,6 +16,34 @@ test_that("str_interp works with default env", {
   )
 })
 
+test_that("str_interp is vectorised", {
+  name <- c("Alice", "Alice", "Bob", "Bob")
+  lap <- rep(1:2, 2)
+  time <- c(6.656, 7.032, 6.293, 7.2)
+
+  expect_equal(
+    str_interp("name: ${name}. lap: $[d]{lap}. time $[.2f]{time}."),
+    c("name: Alice. lap: 1. time 6.66.", "name: Alice. lap: 2. time 7.03.",
+      "name: Bob. lap: 1. time 6.29.", "name: Bob. lap: 2. time 7.20." )
+  )
+})
+
+test_that("str_interp recycles length 1 vectors", {
+  lap <- 1:3
+  time <- 6.656
+
+  expect_equal(
+    str_interp("lap: $[d]{lap}. time: $[.2f]{time}."),
+    c("lap: 1. time: 6.66.", "lap: 2. time: 6.66.", "lap: 3. time: 6.66.")
+  )
+
+  time <- c(6.656, 6.7)
+  expect_error(
+    str_interp("lap: $[d]{lap}. time: $[.2f]{time}."),
+    "Not all expressions in interpolated strings have same length or length 1."
+  )
+})
+
 test_that("str_interp works with lists and data frames.", {
   expect_equal(
     str_interp(


### PR DESCRIPTION
I like the handling of vectors in `paste()` a lot in that it cycles over all the elements of the input expressions:

```
paste(month.abb[1:2], "is the", 1:2, "month of the year.")
# "Jan is the 1 month of the year." "Feb is the 2 month of the year."
```

I think the behaviour of `str_interp()` is less useful and not intuitive here:

```
str_interp("${month.abb[1:2]} is the ${1:2} month of the year.")
# "Jan is the Feb month of the year."
```

One should at least get a warning or rather an error for this unexpected behaviour.
With the pull request one gets instead

```
str_interp("${month.abb[1:2]} is the ${1:2} month of the year.")
# "Jan is the 1 month of the year." "Feb is the 2 month of the year."
```

As this breaks the current behaviour one might want to add an extra parameter for allowing this.