### PR TITLE
Spelling and grammar

### DIFF
--- a/vignettes/stringr.Rmd
+++ b/vignettes/stringr.Rmd
@@ -17,8 +17,8 @@ knitr::opts_chunk$set(
 
 There are four main families of functions in stringr: 
 
-1.  Character manipulation: these functions allow you to manipulate the 
-    individual characters inside the strings inside character vectors.
+1.  Character manipulation: these functions allow you to manipulate 
+    individual characters within the strings in character vectors.
    
 1.  Whitespace tools to add, remove, and manipulate whitespace.
 
@@ -39,7 +39,7 @@ str_length("abc")
 
 This is now equivalent to the base R function `nchar()`. Previously it was needed to work around issues with `nchar()` such as the fact that it returned 2 for `nchar(NA)`. This has been fixed as of R 3.3.0, so it is no longer so important.
 
-You can access individual character using `sub_str()`. It takes three arguments: a character vector, a starting position and an end position. Either position can either be a positive integer, which counts from the length, or a negative integer which counts from the right. The positions are inclusive, and if longer than the string, will be silently truncated.
+You can access individual character using `str_sub()`. It takes three arguments: a character vector, a `start` position and an `end` position. Either position can either be a positive integer, which counts from the length, or a negative integer which counts from the right. The positions are inclusive, and if longer than the string, will be silently truncated.
 
 ```{r}
 x <- c("abcdef", "ghifjk")
@@ -74,7 +74,7 @@ Three functions add, remove, or modify whitespace:
     
     ```{r}
     x <- c("abc", "defghi")
-    str_pad(x, 10)
+    str_pad(x, 10) # default pads on left
     str_pad(x, 10, "both")
     ```
     
@@ -107,7 +107,7 @@ Three functions add, remove, or modify whitespace:
     ```
 
 1.  You can use `str_wrap()` to modify existing whitespace in order to wrap
-    a paragraph of text so that the length of each line as a similar as 
+    a paragraph of text, such that the length of each line is as similar as 
     possible. 
     
     ```{r}
@@ -134,7 +134,7 @@ str_to_lower(x)
 str_to_lower(x, "tr")
 ```
 
-And string ordering and sorting:
+String ordering and sorting:
 
 ```{r}
 x <- c("y", "i", "k")
@@ -183,7 +183,7 @@ phone <- "([2-9][0-9]{2})[- .]([0-9]{3})[- .]([0-9]{4})"
     str_count(strings, phone)
     ```
 
--   `str_locate()` locates the first position of a pattern and returns a numeric 
+-   `str_locate()` locates the **first** position of a pattern and returns a numeric 
     matrix with columns start and end. `str_locate_all()` locates all matches, 
     returning a list of numeric matrices. Similar to `regexpr()` and `gregexpr()`.
 
@@ -193,7 +193,7 @@ phone <- "([2-9][0-9]{2})[- .]([0-9]{3})[- .]([0-9]{4})"
     str_locate_all(strings, phone)
     ```
 
--   `str_extract()` extracts text corresponding to the first match, returning a 
+-   `str_extract()` extracts text corresponding to the **first** match, returning a 
     character vector. `str_extract_all()` extracts all matches and returns a 
     list of character vectors.
 
@@ -204,7 +204,7 @@ phone <- "([2-9][0-9]{2})[- .]([0-9]{3})[- .]([0-9]{4})"
     str_extract_all(strings, phone, simplify = TRUE)
     ```
 
--   `str_match()` extracts capture groups formed by `()` from the first match. 
+-   `str_match()` extracts capture groups formed by `()` from the **first** match. 
     It returns a character matrix with one column for the complete match and 
     one column for each group. `str_match_all()` extracts capture groups from 
     all matches and returns a list of character matrices. Similar to 
@@ -216,7 +216,7 @@ phone <- "([2-9][0-9]{2})[- .]([0-9]{3})[- .]([0-9]{4})"
     str_match_all(strings, phone)
     ```
 
--   `str_replace()` replaces the first matched pattern and returns a character
+-   `str_replace()` replaces the **first** matched pattern and returns a character
     vector. `str_replace_all()` replaces all matches. Similar to `sub()` and 
     `gsub()`.
 
@@ -225,9 +225,9 @@ phone <- "([2-9][0-9]{2})[- .]([0-9]{3})[- .]([0-9]{4})"
     str_replace_all(strings, phone, "XXX-XXX-XXXX")
     ```
 
--   `str_split_fixed()` splits the string into a fixed number of pieces based 
+-   `str_split_fixed()` splits a string into a **fixed** number of pieces based 
     on a pattern and returns a character matrix. `str_split()` splits a string 
-    into a variable number of pieces and returns a list of character vectors.
+    into a **variable** number of pieces and returns a list of character vectors.
     
     ```{r}
     str_split("a-b-c", "-")
@@ -259,8 +259,8 @@ a1 == a2
 ```
 
 They render identically, but because they're defined differently, 
-`fixed()` doesn't find a match. Instead, you can use `coll()`, defined
-next, to respect human character comparison rules:
+`fixed()` doesn't find a match. Instead, you can use `coll()`, explained
+below, to respect human character comparison rules:
 
 ```{r}
 str_detect(a1, fixed(a2))
@@ -279,7 +279,7 @@ str_subset(i, coll("i", ignore_case = TRUE))
 str_subset(i, coll("i", ignore_case = TRUE, locale = "tr"))
 ```
 
-The downside of `coll()` is speed; because the rules for recognising which characters are the same are complicated, `coll()` is relatively slow compared to `regex()` and `fixed()`. Note that when both `fixed()` and `regex()` have `ignore_case` arguments, they perform a much simpler comparison than `coll()`.
+The downside of `coll()` is speed. Because the rules for recognising which characters are the same are complicated, `coll()` is relatively slow compared to `regex()` and `fixed()`. Note that when both `fixed()` and `regex()` have `ignore_case` arguments, they perform a much simpler comparison than `coll()`.
 
 #### Boundary
 


### PR DESCRIPTION
edited some minor phrasing in `vignettes/stringr.Rmd`. More importantly, there is a typo in L42 that gave the wrong function (`sub_str()` instead of `str_sub()`)