### PR TITLE
Add link to tidyverse/glue

### DIFF
--- a/R/interp.R
+++ b/R/interp.R
@@ -8,6 +8,7 @@
 #' \code{$[format]{expression}}, where expressions are valid R expressions that
 #' can be evaluated in the given environment, and \code{format} is a format
 #' specification valid for use with \code{\link{sprintf}}.
+#' A tidyverse friendly alternative is \code{\link{glue}}.
 #'
 #' @param string A template character string. This function is not vectorised:
 #'   a character vector will be collapsed into a single string.


### PR DESCRIPTION
I spent quite a bit of time trying to make str_interp work like tidyverse/glue_data ... my logic was "tidyverse string stuff is in stringr, str_interp sounds right." So just as tidyverse/glue points to str_interp as an option, this points back (I hope, I'm afraid my rdoc is very weak).