### PR TITLE
Clean roxygen doc in str_glue and vignette

### DIFF
--- a/R/c.r
+++ b/R/c.r
@@ -1,12 +1,11 @@
 #' Join multiple strings into a single string.
 #'
-#' To understand how `str_c` works, you need to imagine that you are
-#' building up a matrix of strings. Each input argument forms a column, and
-#' is expanded to the length of the longest argument, using the usual
-#' recyling rules.  The `sep` string is inserted between each column. If
-#' collapse is `NULL` each row is collapsed into a single string. If
-#' non-`NULL` that string is inserted at the end of each row, and
-#' the entire matrix collapsed to a single string.
+#' To understand how `str_c` works, you need to imagine that you are building up
+#' a matrix of strings. Each input argument forms a column, and is expanded to
+#' the length of the longest argument, using the usual recyling rules.  The
+#' `sep` string is inserted between each column. If collapse is `NULL` each row
+#' is collapsed into a single string. If non-`NULL` that string is inserted at
+#' the end of each row, and the entire matrix collapsed to a single string.
 #'
 #' @param ... One or more character vectors. Zero length arguments
 #'   are removed. Short arguments are recycled to the length of the

--- a/R/glue.R
+++ b/R/glue.R
@@ -6,7 +6,6 @@
 #' directly from glue for more control.
 #'
 #' @export
-#' @inheritParams glue::data
 #' @examples
 #' name <- "Fred"
 #' age <- 50

--- a/man/str_c.Rd
+++ b/man/str_c.Rd
@@ -27,13 +27,12 @@ length equal to the longest input string. If \code{collapse} is
 non-NULL, a character vector of length 1.
 }
 \description{
-To understand how \code{str_c} works, you need to imagine that you are
-building up a matrix of strings. Each input argument forms a column, and
-is expanded to the length of the longest argument, using the usual
-recyling rules.  The \code{sep} string is inserted between each column. If
-collapse is \code{NULL} each row is collapsed into a single string. If
-non-\code{NULL} that string is inserted at the end of each row, and
-the entire matrix collapsed to a single string.
+To understand how \code{str_c} works, you need to imagine that you are building up
+a matrix of strings. Each input argument forms a column, and is expanded to
+the length of the longest argument, using the usual recyling rules.  The
+\code{sep} string is inserted between each column. If collapse is \code{NULL} each row
+is collapsed into a single string. If non-\code{NULL} that string is inserted at
+the end of each row, and the entire matrix collapsed to a single string.
 }
 \examples{
 str_c("Letter: ", letters)

--- a/vignettes/releases/stringr-1.2.0.Rmd
+++ b/vignettes/releases/stringr-1.2.0.Rmd
@@ -21,7 +21,7 @@ x %>% str_match_all("(.)=(\\d)?,?")
 
 ## New features
 
-There are three new featuers:
+There are three new features:
 
 *   In `str_replace()`, `replacement` can now be a function that is called once
     for each match and who's return value is used to replace the match.


### PR DESCRIPTION
- There is no `glue::data`. The correct inheritance should be from `glue::glue_data`, which is already being passed on L39.
- Spelling typo in release 1.2.0 article. `pkgdown` needs to be run by a maintainer for the tidyverse website to be updated.
- Reflowed comment for `str_c` description to trigger a travis build, which now passes all checks