### PR TITLE
Fixed unexpected behavior of str_trunc

### DIFF
--- a/R/trunc.R
+++ b/R/trunc.R
@@ -18,7 +18,7 @@ str_trunc <- function(string, width, side = c("right", "left", "center"),
                       ellipsis = "...") {
   side <- match.arg(side)
 
-  too_long <- !is.na(string) && str_length(string) > width
+  too_long <- !is.na(string) & str_length(string) > width
   width... <- width - str_length(ellipsis)
 
   if (width... < 0) stop("`width` is shorter than `ellipsis`", .call = FALSE)

--- a/tests/testthat/test-trunc.r
+++ b/tests/testthat/test-trunc.r
@@ -11,6 +11,13 @@ test_that("NA values in input pass through unchanged", {
   )
 })
 
+test_that("truncations work for all elements of a vector", {
+  expect_equal(
+    str_trunc(c("abcd", "abcde", "abcdef"), width = 5),
+    c("abcd", "abcde", "ab...")
+  )
+})
+
 test_that("truncations work for all sides", {
 
   trunc <- function(direction) str_trunc(


### PR DESCRIPTION
Fixes #203.

With the NA logic fix to str_trunc 2 months ago, "&&" was used instead of "&", causing str_trunc to only work on the first element of the vector.

I added a test as well, but nothing in the NEWS since this change wasn't ever released.