### PR TITLE
Include see also pointer to tidyr::extract

### DIFF
--- a/R/match.r
+++ b/R/match.r
@@ -11,7 +11,8 @@
 #'
 #' @seealso [str_extract()] to extract the complete match,
 #'   [stringi::stri_match()] for the underlying
-#'   implementation.
+#'   implementation, [tidyr::extract()] for convenient form using capturing
+#'   parens to create new columns.
 #' @export
 #' @examples
 #' strings <- c(" 219 733 8965", "329-293-8753 ", "banana", "595 794 7569",


### PR DESCRIPTION
I turned to str_match and str_extract for doing what tidyr::extract does (and tidy::extract is a much more convenient form!). So I added a cross-link to the see also.

Thanks to markdly at community.rstudio.org showing me the right way! https://community.rstudio.com/t/getting-parts-of-string-using-regex-and-capturing-parens-in-mutate