### PR TITLE
Fix typo in regular expressions vignette

### DIFF
--- a/vignettes/regular-expressions.Rmd
+++ b/vignettes/regular-expressions.Rmd
@@ -206,7 +206,7 @@ You can also create your own __character classes__ using `[]`:
 * `[a-z]`: matches every character between a and z 
    (in Unicode code point order).
 * `[^abc]`: matches anything except a, b, or c.
-* `[\^\-]`: matches `-` or `\`.
+* `[\^\-]`: matches `^` or `-`.
 
 There are a number of pre-built classes that you can use inside `[]`:
 


### PR DESCRIPTION
Fixed typo that `[\^]` matches `^` and not `\`. Also changed order to be consistent with presentation in regexp.

Is it worth mentioning here that no backslash is needed if `-` is the first character or if `^` is not the first character in the class? In other words `[\^\-]` is equivalent to `[-^]`. (I guess not, it is easier to just learn the rules as escape both inside the `[]`.)