### PR TITLE
Add detail to boundary() documentation

### DIFF
--- a/R/modifiers.r
+++ b/R/modifiers.r
@@ -107,9 +107,22 @@ regex <- function(pattern, ignore_case = FALSE, multiline = FALSE,
 }
 
 #' @param type Boundary type to detect.
+#' \describe{
+#'  \item{`character`}{Every character is a boundary.}
+#'  \item{`line_break`}{Boundaries are places where it is acceptable to have
+#'    a line break in the current locale.}
+#'  \item{`sentence`}{The beginnings and ends of sentences are boundaries,
+#'    using intelligent rules to avoid counting abbreviations
+#'    ([details](https://www.unicode.org/reports/tr29/#Sentence_Boundaries)).}
+#'  \item{`word`}{The beginnings and ends of words are boundaries.}
+#' }
 #' @param skip_word_none Ignore "words" that don't contain any characters
 #'   or numbers - i.e. punctuation. Default `NA` will skip such "words"
 #'   only when splitting on `word` boundaries.
+#'
+#' @seealso [str_wrap()] for breaking text to form paragraphs
+#' @seealso [`stringi::stringi-search-boundaries`] for more detail on the
+#'   various boundaries
 #' @export
 #' @rdname modifiers
 boundary <- function(type = c("character", "line_break", "sentence", "word"),

--- a/man/modifiers.Rd
+++ b/man/modifiers.Rd
@@ -42,7 +42,16 @@ default, only match the start and end of the input.}
 
 \item{dotall}{If \code{TRUE}, \code{.} will also match line terminators.}
 
-\item{type}{Boundary type to detect.}
+\item{type}{Boundary type to detect.
+\describe{
+\item{\code{character}}{Every character is a boundary.}
+\item{\code{line_break}}{Boundaries are places where it is acceptable to have
+a line break in the current locale.}
+\item{\code{sentence}}{The beginnings and ends of sentences are boundaries,
+using intelligent rules to avoid counting abbreviations
+(\href{https://www.unicode.org/reports/tr29/#Sentence_Boundaries}{details}).}
+\item{\code{word}}{The beginnings and ends of words are boundaries.}
+}}
 
 \item{skip_word_none}{Ignore "words" that don't contain any characters
 or numbers - i.e. punctuation. Default \code{NA} will skip such "words"
@@ -86,4 +95,10 @@ str_extract_all("a\\nb\\nc", regex("^.", multiline = TRUE))
 
 str_extract_all("a\\nb\\nc", "a.")
 str_extract_all("a\\nb\\nc", regex("a.", dotall = TRUE))
+}
+\seealso{
+\code{\link[=str_wrap]{str_wrap()}} for breaking text to form paragraphs
+
+\code{\link[stringi:stringi-search-boundaries]{stringi::stringi-search-boundaries}} for more detail on the
+various boundaries
 }


### PR DESCRIPTION
I assumed `str_split(x, boundary("line_break"))` meant "split `x` on any kind of line-break character".  I was wrong! 

Here are docs I hope are helpful to other people; let me know if you'd like me to change anything.