### PR TITLE
Fixed unexpected behavior of str_trunc (issues #203 and #229)

### DIFF
--- a/R/trunc.R
+++ b/R/trunc.R
@@ -18,7 +18,7 @@ str_trunc <- function(string, width, side = c("right", "left", "center"),
                       ellipsis = "...") {
   side <- match.arg(side)
 
-  too_long <- !is.na(string) && str_length(string) > width
+  too_long <- !is.na(string) & str_length(string) > width
   width... <- width - str_length(ellipsis)
 
   if (width... < 0) stop("`width` is shorter than `ellipsis`", .call = FALSE)

--- a/tests/testthat/test-trunc.r
+++ b/tests/testthat/test-trunc.r
@@ -11,6 +11,13 @@ test_that("NA values in input pass through unchanged", {
   )
 })
 
+test_that("truncations work for all elements of a vector", {
+  expect_equal(
+    str_trunc(c("abcd", "abcde", "abcdef"), width = 5),
+    c("abcd", "abcde", "ab...")
+  )
+})
+
 test_that("truncations work for all sides", {
 
   trunc <- function(direction) str_trunc(


### PR DESCRIPTION
Duplicate of pull request #206, which was broken because TravisCI was using a different serialization format for R-devel checks. See http://r.789695.n4.nabble.com/R-CMD-build-then-check-fails-on-R-devel-due-to-serialization-version-td4747582.html for details.