### PR TITLE
Add markdown output to str_view

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,4 +30,4 @@ Suggests:
 VignetteBuilder: knitr
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 6.0.1
+RoxygenNote: 6.0.1.9000

--- a/man/str_view.Rd
+++ b/man/str_view.Rd
@@ -5,9 +5,10 @@
 \alias{str_view_all}
 \title{View HTML rendering of regular expression match.}
 \usage{
-str_view(string, pattern, match = NA)
+str_view(string, pattern, match = NA, output = c("htmlwidget", "markdown"))
 
-str_view_all(string, pattern, match = NA)
+str_view_all(string, pattern, match = NA, output = c("htmlwidget",
+  "markdown"))
 }
 \arguments{
 \item{string}{Input vector. Either a character vector, or something
@@ -31,6 +32,14 @@ Match character, word, line and sentence boundaries with
 \item{match}{If \code{TRUE}, shows only strings that match the pattern.
 If \code{FALSE}, shows only the strings that don't match the pattern.
 Otherwise (the default, \code{NA}) displays both matches and non-matches.}
+
+\item{output}{If \code{"htmlwidgets"}, then output a \url{HTML widget}.
+If \code{"markdown"}, then output a markdown formatted character vector.}
+}
+\value{
+If \code{output = "htmlwidgets"}, then a
+\link[htmlwidgets:createWidget]{HTML widget}. If \code{output = "markdown"}, then
+a character vector of length one.
 }
 \description{
 \code{str_view} shows the first match; \code{str_view_all} shows all
@@ -48,4 +57,8 @@ str_view_all(c("abc", "def", "fgh"), "d|e")
 str_view(c("abc", "def", "fgh"), "d|e")
 str_view(c("abc", "def", "fgh"), "d|e", match = TRUE)
 str_view(c("abc", "def", "fgh"), "d|e", match = FALSE)
+
+# output markdown
+str_view(c("abc", "def", "fgh"), "[aeiou]", output = "markdown")
+str_view_all(c("abc", "def", "fgh"), "d|e", output = "markdown")
 }

--- a/man/stringr-package.Rd
+++ b/man/stringr-package.Rd
@@ -6,6 +6,8 @@
 \alias{stringr-package}
 \title{stringr: Simple, Consistent Wrappers for Common String Operations}
 \description{
+\if{html}{\figure{logo.png}{options: align='right'}}
+
 A consistent, simple and easy to use set of wrappers around the
 fantastic 'stringi' package. All function and argument names (and positions)
 are consistent, all functions deal with "NA"'s and zero length vectors

--- a/tests/testthat/test-view.R
+++ b/tests/testthat/test-view.R
@@ -25,3 +25,10 @@ test_that("view_all shows all matches", {
   a <- str_view_all(x, "d|e", match = FALSE)
   expect_equal(str_count(a$x$html, "match"), 0)
 })
+
+test_that("view works with markdown output", {
+  expect_equal(str_view(x, "[aeiou]", output = "markdown"),
+               "\n-   **a**bc\n-   d**e**f\n-   fgh\n\n")
+  expect_equal(str_view_all(x, "d|e", output = "markdown"),
+               "\n-   abc\n-   **d****e**f\n-   fgh\n\n")
+})


### PR DESCRIPTION
Add an option to output markdown format from `str_view` rather than just the HTML widget format. This is useful for outputting to LaTeX, or if a simpler format is needed.