### PR TITLE
Add requireNamespace so str_view() fails more gracefully 

### DIFF
--- a/R/view.R
+++ b/R/view.R
@@ -74,9 +74,9 @@ str_view_widget <- function(lines) {
   )
   html <- htmltools::HTML(bullets)
 
-if(!requireNamespace("htmlwidgets", quietly = TRUE)){
-  message("htmlwidgets package required for str_view(). \nPlease install.packages(\"htmlwidgets\") to use this functionality.")
-}else{
+  if (!requireNamespace("htmlwidgets", quietly = TRUE)) {
+    stop("htmlwidgets package required for str_view(). \nPlease install.packages(\"htmlwidgets\") to use this functionality.")
+  }
   size <- htmlwidgets::sizingPolicy(
     knitr.figure = FALSE,
     defaultHeight = pmin(10 * length(lines), 300),
@@ -89,5 +89,4 @@ if(!requireNamespace("htmlwidgets", quietly = TRUE)){
     sizingPolicy = size,
     package = "stringr"
   )
-}
 }

--- a/R/view.R
+++ b/R/view.R
@@ -74,6 +74,9 @@ str_view_widget <- function(lines) {
   )
   html <- htmltools::HTML(bullets)
 
+if(!requireNamespace("htmlwidgets", quietly = TRUE)){
+  message("htmlwidgets package required for str_view(). \nPlease install.packages(\"htmlwidgets\") to use this functionality.")
+}else{
   size <- htmlwidgets::sizingPolicy(
     knitr.figure = FALSE,
     defaultHeight = pmin(10 * length(lines), 300),
@@ -86,4 +89,5 @@ str_view_widget <- function(lines) {
     sizingPolicy = size,
     package = "stringr"
   )
+}
 }

--- a/R/view.R
+++ b/R/view.R
@@ -75,7 +75,8 @@ str_view_widget <- function(lines) {
   html <- htmltools::HTML(bullets)
 
   if (!requireNamespace("htmlwidgets", quietly = TRUE)) {
-    stop("htmlwidgets package required for str_view(). \nPlease install.packages(\"htmlwidgets\") to use this functionality.")
+    stop("htmlwidgets package required for str_view(). \nPlease install.packages(\"htmlwidgets\") to use this functionality.",
+         call. = FALSE)
   }
   size <- htmlwidgets::sizingPolicy(
     knitr.figure = FALSE,


### PR DESCRIPTION
in the absence of htmlwidgets

To fix #263 