### PR TITLE
Add new `replace` parameter in `str_trunc`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: stringr
 Title: Simple, Consistent Wrappers for Common String Operations
-Version: 1.4.0.9001
+Version: 1.4.0.9002
 Authors@R: 
     c(person(given = "Hadley",
              family = "Wickham",
@@ -36,4 +36,4 @@ Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 6.1.1
-Date: 2019-02-18
+Date: 2019-02-19

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: stringr
 Title: Simple, Consistent Wrappers for Common String Operations
-Version: 1.4.0.9000
+Version: 1.4.0.9001
 Authors@R: 
     c(person(given = "Hadley",
              family = "Wickham",
@@ -36,3 +36,4 @@ Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 6.1.1
+Date: 2019-02-18

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # stringr (development version)
 
+* `str_trunc` has a new `replace` parameter which allow ellipsis to be added
+to the string without being counted by the `width` argument.
+
 # stringr 1.4.0
 
 * `str_interp()` now renders lists consistently independent on the presence of

--- a/R/trunc.R
+++ b/R/trunc.R
@@ -4,6 +4,8 @@
 #' @param width Maximum width of string.
 #' @param side,ellipsis Location and content of ellipsis that indicates
 #'   content has been removed.
+#' @param replace if TRUE (default), ellipsis is taken into account in
+#' the width, otherwise ellipsis is added after resizing the string.
 #' @seealso [str_pad()] to increase the minimum width of a string.
 #' @export
 #' @examples
@@ -15,11 +17,11 @@
 #' )
 #'
 str_trunc <- function(string, width, side = c("right", "left", "center"),
-                      ellipsis = "...") {
+                      ellipsis = "...", replace = TRUE) {
   side <- match.arg(side)
 
   too_long <- !is.na(string) & str_length(string) > width
-  width... <- width - str_length(ellipsis)
+  width... <- width - str_length(ellipsis) * replace
 
   if (width... < 0) stop("`width` is shorter than `ellipsis`", .call = FALSE)
 

--- a/man/str_trunc.Rd
+++ b/man/str_trunc.Rd
@@ -5,7 +5,7 @@
 \title{Truncate a character string.}
 \usage{
 str_trunc(string, width, side = c("right", "left", "center"),
-  ellipsis = "...")
+  ellipsis = "...", replace = TRUE)
 }
 \arguments{
 \item{string}{A character vector.}
@@ -14,6 +14,9 @@ str_trunc(string, width, side = c("right", "left", "center"),
 
 \item{side, ellipsis}{Location and content of ellipsis that indicates
 content has been removed.}
+
+\item{replace}{if TRUE (default), ellipsis is taken into account in
+the width, otherwise ellipsis is added after resizing the string.}
 }
 \description{
 Truncate a character string.

--- a/tests/testthat/test-trunc.r
+++ b/tests/testthat/test-trunc.r
@@ -36,3 +36,9 @@ test_that("does not truncate to a length shorter than elipsis", {
   expect_error(str_trunc("foobar", 2))
   expect_error(str_trunc("foobar", 3, ellipsis = "...."))
 })
+
+test_that("does not take into account size of ellipsis in the width", {
+
+  expect_equal(str_trunc("foobar", 2, replace = FALSE), "fo...")
+  expect_equal(str_trunc("foobar", 3, ellipsis = "....", replace = FALSE), "foo....")
+})


### PR DESCRIPTION
This parameter allows the ellipsis to be added after truncation is done, i.e. without being taken into account in the `width` parameter.

## Example

``` r
library(stringr)
library(dplyr)
#> 
#> Attachement du package : 'dplyr'
#> The following objects are masked from 'package:stats':
#> 
#>     filter, lag
#> The following objects are masked from 'package:base':
#> 
#>     intersect, setdiff, setequal, union
library(glue)
#> 
#> Attachement du package : 'glue'
#> The following object is masked from 'package:dplyr':
#> 
#>     collapse

set.seed(123)
df <- tibble(value = sample(0:9, 30, replace = TRUE), group = sample(c("a", "b", "c"), 30, replace = TRUE))

df %>% 
  group_by(group) %>% 
  summarise(value = str_trunc(toString(value), 7, ellipsis = glue(" ... + {length(value) - 1} more."), replace = FALSE))
#> # A tibble: 3 x 2
#>   group value                 
#>   <chr> <chr>                 
#> 1 a     9, 8, 5 ... + 12 more.
#> 2 b     0, 4, 6 ... + 7 more. 
#> 3 c     2, 7, 4 ... + 8 more.
```

<sup>Created on 2019-02-18 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>