### PR TITLE
🍍 Fix spelling on pineapple in example.

### DIFF
--- a/R/detect.r
+++ b/R/detect.r
@@ -69,7 +69,7 @@ str_detect <- function(string, pattern, negate = FALSE) {
 #' @seealso [str_detect()] which this function wraps when pattern is regex.
 #' @export
 #' @examples
-#' fruit <- c("apple", "banana", "pear", "pinapple")
+#' fruit <- c("apple", "banana", "pear", "pineapple")
 #' str_starts(fruit, "p")
 #' str_starts(fruit, "p", negate = TRUE)
 #' str_ends(fruit, "e")

--- a/man/str_starts.Rd
+++ b/man/str_starts.Rd
@@ -32,7 +32,7 @@ A logical vector.
 Vectorised over \code{string} and \code{pattern}.
 }
 \examples{
-fruit <- c("apple", "banana", "pear", "pinapple")
+fruit <- c("apple", "banana", "pear", "pineapple")
 str_starts(fruit, "p")
 str_starts(fruit, "p", negate = TRUE)
 str_ends(fruit, "e")


### PR DESCRIPTION
* Correct spelling of "pineapple" in example for `str_starts()` and `str_ends()`.