### PR TITLE
Fix str_starts() and str_ends() with negate

### DIFF
--- a/R/detect.r
+++ b/R/detect.r
@@ -79,8 +79,8 @@ str_starts <- function(string, pattern, negate = FALSE) {
     type(pattern),
     empty = ,
     bound = stop("boundary() patterns are not supported."),
-    fixed = stri_startswith_fixed(string, pattern, negate = negate, opts_fixed = opts(pattern)),
-    coll  = stri_startswith_coll(string,  pattern, negate = negate, opts_collator = opts(pattern)),
+    fixed = xor(stri_startswith_fixed(string, pattern, opts_fixed = opts(pattern)), negate),
+    coll  = xor(stri_startswith_coll(string,  pattern, opts_collator = opts(pattern)), negate),
     regex = {
       pattern2 <- paste0("^", pattern)
       attributes(pattern2) <- attributes(pattern)
@@ -95,8 +95,8 @@ str_ends <- function(string, pattern, negate = FALSE) {
   switch(type(pattern),
          empty = ,
          bound = stop("boundary() patterns are not supported."),
-         fixed = stri_endswith_fixed(string, pattern, negate = negate, opts_fixed = opts(pattern)),
-         coll  = stri_endswith_coll(string,  pattern, negate = negate, opts_collator = opts(pattern)),
+         fixed = xor(stri_endswith_fixed(string, pattern, opts_fixed = opts(pattern)), negate),
+         coll  = xor(stri_endswith_coll(string,  pattern, opts_collator = opts(pattern)), negate),
          regex = {
            pattern2 <- paste0(pattern, "$")
            attributes(pattern2) <- attributes(pattern)

--- a/tests/testthat/test-detect.r
+++ b/tests/testthat/test-detect.r
@@ -28,10 +28,18 @@ test_that("modifiers work", {
 test_that("str_starts works", {
   expect_true(str_starts("ab", "a"))
   expect_false(str_starts("ab", "b"))
+  expect_true(str_starts("ab", fixed("a")))
+  expect_false(str_starts("ab", fixed("b")))
+  expect_true(str_starts("ab", coll("a")))
+  expect_false(str_starts("ab", coll("b")))
 
   # negation
   expect_false(str_starts("ab", "a", TRUE))
   expect_true(str_starts("ab", "b", TRUE))
+  expect_false(str_starts("ab", fixed("a"), TRUE))
+  expect_true(str_starts("ab", fixed("b"), TRUE))
+  expect_false(str_starts("ab", coll("a"), TRUE))
+  expect_true(str_starts("ab", coll("b"), TRUE))
 
   # Special typing of patterns.
   expect_true(str_starts("ab", fixed("A", ignore_case = TRUE)))
@@ -41,10 +49,18 @@ test_that("str_starts works", {
 test_that("str_ends works", {
   expect_true(str_ends("ab", "b"))
   expect_false(str_ends("ab", "a"))
+  expect_true(str_ends("ab", fixed("b")))
+  expect_false(str_ends("ab", fixed("a")))
+  expect_true(str_ends("ab", coll("b")))
+  expect_false(str_ends("ab", coll("a")))
 
   # negation
   expect_false(str_ends("ab", "b", TRUE))
   expect_true(str_ends("ab", "a", TRUE))
+  expect_false(str_ends("ab", fixed("b"), TRUE))
+  expect_true(str_ends("ab", fixed("a"), TRUE))
+  expect_false(str_ends("ab", coll("b"), TRUE))
+  expect_true(str_ends("ab", coll("a"), TRUE))
 
   # Special typing of patterns.
   expect_true(str_ends("ab", fixed("B", ignore_case = TRUE)))


### PR DESCRIPTION
This is fixing issue #327 for me. I'm not quite sure it's OK to assume `negate` is scalar, what do you think?