### PR TITLE
make detect helpers honor regex "|" operator

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # stringr (development version)
 
+* Update `str_starts()` and `str_ends()` functions so they honor regex "|" operator more intuitively. (@carlganz)
+
 * `word()` now returns all the sentence when using a negative `start` parameter
   that is greater or equal than the number of words. (@pdelboca, #245)
 

--- a/R/detect.r
+++ b/R/detect.r
@@ -82,7 +82,7 @@ str_starts <- function(string, pattern, negate = FALSE) {
     fixed = stri_startswith_fixed(string, pattern, negate = negate, opts_fixed = opts(pattern)),
     coll  = stri_startswith_coll(string,  pattern, negate = negate, opts_collator = opts(pattern)),
     regex = {
-      pattern2 <- paste0("^", pattern)
+      pattern2 <- paste0("^(", pattern, ")")
       attributes(pattern2) <- attributes(pattern)
       str_detect(string, pattern2, negate)
     }
@@ -98,7 +98,7 @@ str_ends <- function(string, pattern, negate = FALSE) {
          fixed = stri_endswith_fixed(string, pattern, negate = negate, opts_fixed = opts(pattern)),
          coll  = stri_endswith_coll(string,  pattern, negate = negate, opts_collator = opts(pattern)),
          regex = {
-           pattern2 <- paste0(pattern, "$")
+           pattern2 <- paste0("(", pattern, ")$")
            attributes(pattern2) <- attributes(pattern)
            str_detect(string, pattern2, negate)
          }

--- a/tests/testthat/test-detect.r
+++ b/tests/testthat/test-detect.r
@@ -36,6 +36,10 @@ test_that("str_starts works", {
   # Special typing of patterns.
   expect_true(str_starts("ab", fixed("A", ignore_case = TRUE)))
   expect_true(str_starts("ab", regex("A", ignore_case = TRUE)))
+
+  # Or operators are respected
+  expect_true(str_starts("ab", regex("B|A", ignore_case = TRUE)))
+  expect_false(str_starts("ab", regex("C|B", ignore_case = TRUE)))
 })
 
 test_that("str_ends works", {
@@ -48,6 +52,10 @@ test_that("str_ends works", {
 
   # Special typing of patterns.
   expect_true(str_ends("ab", fixed("B", ignore_case = TRUE)))
+
+  # Or operators are respected
+  expect_true(str_ends("ab", regex("B|A", ignore_case = TRUE)))
+  expect_false(str_ends("ab", regex("C|A", ignore_case = TRUE)))
 })
 
 


### PR DESCRIPTION
Apropos of this [twitter thread](https://twitter.com/carlishganzino/status/1266519160374190081?s=20) here is small PR that updates detect helpers so that they honor regex "|" operator more intuitively. It doesn't break any existing tests, but I didn't run full revdepcheck because I don't want my computer to catch fire. 

I'm sure there will be cases where somebody has code that depends on the previous functionality, but I feel pretty strongly that this change makes the API more intuitive.