### PR TITLE
return all NA rows/cols for no matches in matrix results

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # stringr (development version)
 
+* Always return at least 1x1 matrix from `str_extract_all(simplify = TRUE)`.
+  This introduces a small, potentially breaking change:
+  No matches are now returned as `NA_character`, not as `""`.
+  (@maxheld83, #366)
+
 * Update `str_starts()` and `str_ends()` functions so they honor regex operator precedence. (@carlganz)
 
 * `word()` now returns all the sentence when using a negative `start` parameter

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,12 @@
 # stringr (development version)
 
-* Always return at least 1x1 matrix from `str_extract_all(simplify = TRUE)`.
+* `str_extract_all(simplify = TRUE)` and `str_match_all()` now always return
+  all combinations of given `string` and `pattern` as a matrix of their 
+  cartesian product.
+  Previously, rows or columns without matches would be dropped.
   This introduces a small, potentially breaking change:
-  No matches are now returned as `NA_character`, not as `""`.
-  (@maxheld83, #366)
+  No matches in matrices are now returned as `NA_character` in
+  `str_extract_all(simplify = TRUE)`, not `""`. (@maxheld83, #366)
 
 * Update `str_starts()` and `str_ends()` functions so they honor regex operator precedence. (@carlganz)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,12 +1,12 @@
 # stringr (development version)
 
-* `str_extract_all(simplify = TRUE)` and `str_match_all()` now always return
-  all combinations of given `string` and `pattern` as a matrix of their 
-  cartesian product.
-  Previously, rows or columns without matches would be dropped.
-  This introduces a small, potentially breaking change:
-  No matches in matrices are now returned as `NA_character` in
-  `str_extract_all(simplify = TRUE)`, not `""`. (@maxheld83, #366)
+* `str_extract_all(simplify = TRUE)`, `str_locate_all()` and `str_match_all()`
+  now always return all combinations in a matrix, even if some rows or columns
+  have no matches at all. Previously, rows or colums without matches would be
+  quietly dropped.
+  As a corollary, this introduces a small, potentially breaking change:
+  In `str_extract_all(simplify = TRUE)`, no matches in matrices are now returned
+  as `NA_character` not `""`. (@maxheld83, #366)
 
 * Update `str_starts()` and `str_ends()` functions so they honor regex operator precedence. (@carlganz)
 

--- a/R/extract.r
+++ b/R/extract.r
@@ -43,16 +43,19 @@ str_extract <- function(string, pattern) {
 #' @rdname str_extract
 #' @export
 str_extract_all <- function(string, pattern, simplify = FALSE) {
+  omit_no_match <- !simplify
+  # NA lets stringi always return NA cells
+  simplify <- ifelse(simplify, NA, FALSE)
   switch(type(pattern),
     empty = stri_extract_all_boundaries(string, pattern,
-      simplify = simplify, omit_no_match = !simplify, opts_brkiter = opts(pattern)),
+      simplify = simplify, omit_no_match = omit_no_match, opts_brkiter = opts(pattern)),
     bound = stri_extract_all_boundaries(string, pattern,
-      simplify = simplify, omit_no_match = !simplify, opts_brkiter = opts(pattern)),
+      simplify = simplify, omit_no_match = omit_no_match, opts_brkiter = opts(pattern)),
     fixed = stri_extract_all_fixed(string, pattern,
-      simplify = simplify, omit_no_match = !simplify, opts_fixed = opts(pattern)),
+      simplify = simplify, omit_no_match = omit_no_match, opts_fixed = opts(pattern)),
     coll  = stri_extract_all_coll(string, pattern,
-      simplify = simplify, omit_no_match = !simplify, opts_collator = opts(pattern)),
+      simplify = simplify, omit_no_match = omit_no_match, opts_collator = opts(pattern)),
     regex = stri_extract_all_regex(string, pattern,
-      simplify = simplify, omit_no_match = !simplify, opts_regex = opts(pattern))
+      simplify = simplify, omit_no_match = omit_no_match, opts_regex = opts(pattern))
   )
 }

--- a/R/extract.r
+++ b/R/extract.r
@@ -3,7 +3,10 @@
 #' Vectorised over `string` and `pattern`.
 #'
 #' @inheritParams str_detect
-#' @return A character vector.
+#' @return 
+#' A character vector.
+#' If `simplify = FALSE`, no matches are returned as 0-length character vectors.
+#' If `simplify = TRUE`, no matches are returned as `NA_character_`.
 #' @seealso [str_match()] to extract matched groups;
 #'   [stringi::stri_extract()] for the underlying implementation.
 #' @param simplify If `FALSE`, the default, returns a list of character
@@ -42,14 +45,14 @@ str_extract <- function(string, pattern) {
 str_extract_all <- function(string, pattern, simplify = FALSE) {
   switch(type(pattern),
     empty = stri_extract_all_boundaries(string, pattern,
-      simplify = simplify, omit_no_match = TRUE, opts_brkiter = opts(pattern)),
+      simplify = simplify, omit_no_match = !simplify, opts_brkiter = opts(pattern)),
     bound = stri_extract_all_boundaries(string, pattern,
-      simplify = simplify, omit_no_match = TRUE, opts_brkiter = opts(pattern)),
+      simplify = simplify, omit_no_match = !simplify, opts_brkiter = opts(pattern)),
     fixed = stri_extract_all_fixed(string, pattern,
-      simplify = simplify, omit_no_match = TRUE, opts_fixed = opts(pattern)),
+      simplify = simplify, omit_no_match = !simplify, opts_fixed = opts(pattern)),
     coll  = stri_extract_all_coll(string, pattern,
-      simplify = simplify, omit_no_match = TRUE, opts_collator = opts(pattern)),
+      simplify = simplify, omit_no_match = !simplify, opts_collator = opts(pattern)),
     regex = stri_extract_all_regex(string, pattern,
-      simplify = simplify, omit_no_match = TRUE, opts_regex = opts(pattern))
+      simplify = simplify, omit_no_match = !simplify, opts_regex = opts(pattern))
   )
 }

--- a/R/locate.r
+++ b/R/locate.r
@@ -41,11 +41,11 @@ str_locate_all <- function(string, pattern) {
   opts <- opts(pattern)
 
   switch(type(pattern),
-    empty = stri_locate_all_boundaries(string, omit_no_match = TRUE, opts_brkiter = opts),
-    bound = stri_locate_all_boundaries(string, omit_no_match = TRUE, opts_brkiter = opts),
-    fixed = stri_locate_all_fixed(string, pattern, omit_no_match = TRUE, opts_fixed = opts),
-    regex = stri_locate_all_regex(string, pattern, omit_no_match = TRUE, opts_regex = opts),
-    coll  = stri_locate_all_coll(string, pattern, omit_no_match = TRUE, opts_collator = opts)
+    empty = stri_locate_all_boundaries(string, opts_brkiter = opts),
+    bound = stri_locate_all_boundaries(string, opts_brkiter = opts),
+    fixed = stri_locate_all_fixed(string, pattern, opts_fixed = opts),
+    regex = stri_locate_all_regex(string, pattern, opts_regex = opts),
+    coll  = stri_locate_all_coll(string, pattern, opts_collator = opts)
   )
 }
 

--- a/R/match.r
+++ b/R/match.r
@@ -53,7 +53,6 @@ str_match_all <- function(string, pattern) {
 
   stri_match_all_regex(string,
     pattern,
-    omit_no_match = TRUE,
     opts_regex = opts(pattern)
   )
 }

--- a/man/str_extract.Rd
+++ b/man/str_extract.Rd
@@ -33,6 +33,8 @@ vectors. If \code{TRUE} returns a character matrix.}
 }
 \value{
 A character vector.
+If \code{simplify = FALSE}, no matches are returned as 0-length character vectors.
+If \code{simplify = TRUE}, no matches are returned as \code{NA_character_}.
 }
 \description{
 Vectorised over \code{string} and \code{pattern}.

--- a/tests/testthat/test-extract.r
+++ b/tests/testthat/test-extract.r
@@ -19,6 +19,17 @@ test_that("no match yields empty vector", {
   expect_equal(str_extract_all("a", "b")[[1]], character())
 })
 
+test_that("str_extract_all returns matrix of at least 1x1 for simplify", {
+  no_match <- str_extract_all("foo", pattern = "bar", simplify = TRUE)
+  expect_equal(no_match, matrix(NA_character_))
+  one_match <- str_extract_all(
+    string = c("foo", "bar"),
+    pattern = "bar",
+    simplify = TRUE
+  )
+  expect_equal(one_match, matrix(c(NA_character_, "bar"), ncol = 1))
+})
+
 test_that("str_extract extracts first match if found, NA otherwise", {
   shopping_list <- c("apples x4", "bag of flour", "bag of sugar", "milk x2")
   word_1_to_4 <- str_extract(shopping_list, "\\b[a-z]{1,4}\\b")

--- a/tests/testthat/test-extract.r
+++ b/tests/testthat/test-extract.r
@@ -30,6 +30,13 @@ test_that("str_extract_all returns matrix of at least 1x1 for simplify", {
   expect_equal(one_match, matrix(c(NA_character_, "bar"), ncol = 1))
 })
 
+test_that("str_extract_all fills no-matches with NAs for simplify", {
+  expect_equal(
+    str_extract_all(c("a b b", "a"), pattern = "b", simplify = TRUE)[2, ],
+    c(NA_character_, NA_character_)
+  )
+})
+
 test_that("str_extract extracts first match if found, NA otherwise", {
   shopping_list <- c("apples x4", "bag of flour", "bag of sugar", "milk x2")
   word_1_to_4 <- str_extract(shopping_list, "\\b[a-z]{1,4}\\b")

--- a/tests/testthat/test-locate.r
+++ b/tests/testthat/test-locate.r
@@ -31,3 +31,15 @@ test_that("both string and patterns are vectorised", {
   expect_equal(locs[[1]][, "start"], c(1, 3))
   expect_equal(locs[[2]][, "start"], c(2, 4))
 })
+
+test_that("`str_locate_all()` returns all NA rows for no matches", {
+  expect_equal(
+    str_locate_all("foo", "bar")[[1]],
+    matrix(
+      NA_integer_,
+      nrow = 1,
+      ncol = 2,
+      dimnames = list(NULL, list("start", "end"))
+    )
+  )
+})

--- a/tests/testthat/test-match.r
+++ b/tests/testthat/test-match.r
@@ -56,6 +56,13 @@ test_that("match_all returns NA when option group doesn't match", {
   expect_equal(str_match_all("a", "(a)(b)?")[[1]][1, ], c("a", "a", NA))
 })
 
+test_that("match_all returns all NA row when there are only no matches", {
+  expect_equal(
+    str_match_all("foo", "(a)(b)")[[1]],
+    matrix(rep(NA_character_, 3), nrow = 1)
+  )
+})
+
 test_that("multiple match works", {
   phones_one <- str_c(phones, collapse = " ")
   multi_match <- str_match_all(phones_one,


### PR DESCRIPTION
Closes #366.

The matrix returns from `str_extract_all(simplify = TRUE)`, `str_locate_all()` and `str_match_all()` would previously drop rows or columns without any matches (details and reprexes in #366).
This can make it harder to work with these functions, because callers have to anticipate differently structured results (for example `x[1, ]`) may fail).
The old behavior made these functions length-unstable (am I using this right?).

If this is even a desirable change, the biggest problem I can see is that this is a (small) **breaking change**.
I'll address the sources of breaking separately:

1. Some other package code might now expect the above dropping behavior.
    Happily, this dropping was nowhere documented nor tested.
    Some `ncol(x) == 0` or similar conditions (if they are ever used) would no longer trigger, but presumably however reverse dependent code dealt with `NA`s would still work, and may cover an *all*-`NA` row/col just fine.
    This is speculation and will require someone with more experience and maybe revdepcheck results.
2. As a corollary of these fixes, `str_extract_all(simplify = TRUE)` now returns `NA`s for no matches, not `""`.
     I'm guessing this is more likely to be a breaking change.
     It is also not currently documented or tested, but still.
     One *could* work around this with by replacing `NA`s with `""` again, though the long-term plan (as per #195) seems to be to standardise on `NA` anyway, so this might be a stop-gap and cause headaches twice.

