### PR TITLE
Fix knitr installation on r-devel

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -53,6 +53,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
+          cache-version: 2
           extra-packages: any::rcmdcheck
           needs: check
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,7 @@ Depends:
 Imports: 
     cli,
     ellipsis,
-    glue (>= 1.2.0),
+    glue (>= 1.6.0.9000),
     lifecycle,
     magrittr,
     rlang,
@@ -37,6 +37,8 @@ Suggests:
     testthat (>= 3.0.0)
 VignetteBuilder: 
     knitr
+Remotes: 
+    tidyverse/glue
 Config/Needs/website: tidyverse/tidytemplate
 Config/testthat/edition: 3
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,7 +38,7 @@ Suggests:
 VignetteBuilder: 
     knitr
 Remotes: 
-    tidyverse/glue@fix-knitr-onload
+    tidyverse/glue
 Config/Needs/website: tidyverse/tidytemplate
 Config/testthat/edition: 3
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,7 +38,7 @@ Suggests:
 VignetteBuilder: 
     knitr
 Remotes: 
-    tidyverse/glue
+    tidyverse/glue@fix-knitr-onload
 Config/Needs/website: tidyverse/tidytemplate
 Config/testthat/edition: 3
 Encoding: UTF-8


### PR DESCRIPTION
dev glue has a fix for the problem cropping up in stringr's CI where knitr fails to install

More detail is here: https://github.com/tidyverse/glue/pull/254

stringr is basically a bystander here, though stringr's `importFrom(glue,glue)` is part of the story