### PR TITLE
Don't need dev glue anymore

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,7 @@ Depends:
 Imports: 
     cli,
     ellipsis,
-    glue (>= 1.6.0.9000),
+    glue (>= 1.6.1),
     lifecycle,
     magrittr,
     rlang,
@@ -37,8 +37,6 @@ Suggests:
     testthat (>= 3.0.0)
 VignetteBuilder: 
     knitr
-Remotes: 
-    tidyverse/glue
 Config/Needs/website: tidyverse/tidytemplate
 Config/testthat/edition: 3
 Encoding: UTF-8


### PR DESCRIPTION
glue 1.6.1 is on CRAN now

Prior to this little maneuver, stringr's minimum version of glue was 1.2.0. And as far as runtime is concerned, I have no reason to believe stringr needs glue 1.6.1.

glue 1.6.1 just addresses a weird knitr installation edge case that affected glue 1.5.1 and 1.6.0 and has only been seen in CI for stringr. So if you don't want to *force* glue to be updated, you can probably go back to the way it was before.