### PR TITLE
Fix str_view_all() deprecation warning test

### DIFF
--- a/R/view.R
+++ b/R/view.R
@@ -80,7 +80,7 @@ str_view <- function(string, pattern = NULL, match = TRUE, html = FALSE, use_esc
 #' @usage NULL
 #' @export
 str_view_all <- function(string, pattern = NULL, match = NA, html = FALSE, use_escapes = FALSE) {
-  lifecycle::deprecate_warn("1.5.0", "str_view()", "str_view_all()")
+  lifecycle::deprecate_warn("1.5.0", "str_view_all()", "str_view()")
 
   str_view(
     string = string,

--- a/tests/testthat/_snaps/view.md
+++ b/tests/testthat/_snaps/view.md
@@ -97,8 +97,8 @@
       str_view_all("abc", "a|b")
     Condition
       Warning:
-      `str_view()` was deprecated in stringr 1.5.0.
-      i Please use `str_view_all()` instead.
+      `str_view_all()` was deprecated in stringr 1.5.0.
+      i Please use `str_view()` instead.
     Output
       [1] | <a><b>c
 


### PR DESCRIPTION
In 1.5.0, str_view() was improved and as a result str_view_all() [was made redundant and was deprecated.](https://www.tidyverse.org/blog/2022/12/stringr-1-5-0/#str_view)  However, the deprecation warning that is displayed when str_view_all() is called states that str_view() is deprecated and that str_view_all() should be used. This change corrects the warning to say that str_view_all() is deprecated and that str_view() should be used. Fixes issue #488. Added with #490 after forgetting to update snapshot tests.