### PR TITLE
Fix bug in str_trunc()

### DIFF
--- a/R/trunc.R
+++ b/R/trunc.R
@@ -32,13 +32,19 @@ str_trunc <- function(string, width, side = c("right", "left", "center"),
     )
   }
 
+  str_sub_tail <- function(string, start) {
+    ifelse(start == 0,
+           "",
+           str_sub(string, start, -1))
+  }
+
   string[too_long] <- switch(side,
     right  = str_c(str_sub(string[too_long], 1, width...), ellipsis),
-    left   = str_c(ellipsis, str_sub(string[too_long], -width..., -1)),
+    left   = str_c(ellipsis, str_sub_tail(string[too_long], -width...)),
     center = str_c(
         str_sub(string[too_long], 1, ceiling(width... / 2)),
         ellipsis,
-        str_sub(string[too_long], -floor(width... / 2), -1)
+        str_sub_tail(string[too_long], -floor(width... / 2))
       )
   )
   string

--- a/tests/testthat/test-trunc.R
+++ b/tests/testthat/test-trunc.R
@@ -18,15 +18,27 @@ test_that("truncations work for all elements of a vector", {
 
 test_that("truncations work for all sides", {
 
-  trunc <- function(direction) str_trunc(
+  trunc <- function(direction, width) str_trunc(
     "This string is moderately long",
     direction,
-    width = 20
+    width = width
   )
 
-  expect_equal(trunc("right"),   "This string is mo...")
-  expect_equal(trunc("left"),    "...s moderately long")
-  expect_equal(trunc("center"),  "This stri...ely long")
+  expect_equal(trunc("right", 20),  "This string is mo...")
+  expect_equal(trunc("left", 20),   "...s moderately long")
+  expect_equal(trunc("center", 20), "This stri...ely long")
+
+  expect_equal(trunc("right", 3),  "...")
+  expect_equal(trunc("left", 3),   "...")
+  expect_equal(trunc("center", 3), "...")
+
+  expect_equal(trunc("right", 4),  "T...")
+  expect_equal(trunc("left", 4),   "...g")
+  expect_equal(trunc("center", 4), "T...")
+
+  expect_equal(trunc("right", 5),  "Th...")
+  expect_equal(trunc("left", 5),   "...ng")
+  expect_equal(trunc("center", 5), "T...g")
 })
 
 test_that("does not truncate to a length shorter than elipsis", {


### PR DESCRIPTION
I found a bug in `str_trunc()` where strings are not properly truncated when `width` is small, as shown below.
The bug seems to be caused by `str_sub("abc", 0, -1)` outputting `"abc"` instead of `""`.
I have fixed the bug by changing the behaviour of getting the tail of the strings.

``` r
library(stringr)

trunc <- function(direction, width) str_trunc(
  "This string is moderately long",
  direction,
  width = width
)

trunc("left", 3)
#> [1] "...This string is moderately long"
trunc("center", 3)
#> [1] "...This string is moderately long"
trunc("center", 4)
#> [1] "T...This string is moderately long"

str_sub("abc", 0, -1)
#> [1] "abc"
# => Not equal to ""
```

<sup>Created on 2023-01-14 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
