### PR TITLE
Corrected str_trunc() to pass correct 'left' and 'center' values to str_sub() when internal variable `width...` is 0 or 1 

### DIFF
--- a/R/trunc.R
+++ b/R/trunc.R
@@ -30,15 +30,21 @@ str_trunc <- function(string, width, side = c("right", "left", "center"),
     cli::cli_abort(
       "`width` ({width}) is shorter than `ellipsis` ({str_length(ellipsis)})."
     )
+  } else if (width... > 1) {
+    end_c <- end_l <- -1
+  } else if (width... == 1) {
+    end_c <- 0; end_l <- -1
+  } else {
+    end_c <- end_l <- 0
   }
 
   string[too_long] <- switch(side,
     right  = str_c(str_sub(string[too_long], 1, width...), ellipsis),
-    left   = str_c(ellipsis, str_sub(string[too_long], -width..., -1)),
+    left   = str_c(ellipsis, str_sub(string[too_long], -width..., end_l)),
     center = str_c(
         str_sub(string[too_long], 1, ceiling(width... / 2)),
         ellipsis,
-        str_sub(string[too_long], -floor(width... / 2), -1)
+        str_sub(string[too_long], -floor(width... / 2), end_c)
       )
   )
   string

--- a/tests/testthat/test-trunc.R
+++ b/tests/testthat/test-trunc.R
@@ -35,3 +35,12 @@ test_that("does not truncate to a length shorter than elipsis", {
     str_trunc("foobar", 3, ellipsis = "....")
   })
 })
+
+test_that("right side of ellipsis correctly substrings when internal var `width...` is 0 or 1", {
+  expect_equal(str_trunc(c('', 'a', 'aa', 'aaa', 'aaaa','aaaaa'), width = 3, "center", ".."),
+               c('', 'a', 'aa', 'aaa', 'a..','a..'))
+  expect_equal(str_trunc(c('', 'a', 'aa', 'aaa', 'aaaa','aaaaa'), width = 2, "left", ".."),
+               c('', 'a', 'aa', '..', '..','..'))
+})
+
+

--- a/tests/testthat/test-trunc.R
+++ b/tests/testthat/test-trunc.R
@@ -37,10 +37,12 @@ test_that("does not truncate to a length shorter than elipsis", {
 })
 
 test_that("right side of ellipsis correctly substrings when internal var `width...` is 0 or 1", {
-  expect_equal(str_trunc(c('', 'a', 'aa', 'aaa', 'aaaa','aaaaa'), width = 3, "center", ".."),
-               c('', 'a', 'aa', 'aaa', 'a..','a..'))
-  expect_equal(str_trunc(c('', 'a', 'aa', 'aaa', 'aaaa','aaaaa'), width = 2, "left", ".."),
-               c('', 'a', 'aa', '..', '..','..'))
+  expect_equal(str_trunc(c('', 'a', 'aa', 'aaa', 'aaaa','aaaaa'), width = 3, "center", ".."), c('', 'a', 'aa', 'aaa', 'a..','a..')) # width... == 1
+  expect_equal(str_trunc(c('', 'a', 'aa', 'aaa', 'aaaa','aaaaa'), width = 3, "left", ".."), c('', 'a', 'aa', 'aaa', '..a','..a')) # width... == 1
+  expect_equal(str_trunc(c('', 'a', 'aa', 'aaa', 'aaaa','aaaaa'), width = 2, "center", ".."), c('', 'a', 'aa', '..', '..','..')) # width... == 0
+  expect_equal(str_trunc(c('', 'a', 'aa', 'aaa', 'aaaa','aaaaa'), width = 2, "left", ".."), c('', 'a', 'aa', '..', '..','..')) # width... == 0
+  expect_equal(str_trunc(c('', 'a', 'aa', 'aaa', 'aaaa','aaaaa'), width = 1, "center", ""), c('', 'a', 'a', 'a', 'a','a')) # width... == 1, empty ellipsis
+  expect_equal(str_trunc(c('', 'a', 'aa', 'aaa', 'aaaa','aaaaa'), width = 1, "left", ""), c('', 'a', 'a', 'a', 'a','a')) # width... == 1, empty ellipsis
 })
 
 


### PR DESCRIPTION
Correction should close Issue #512 and #494.

Note: in my tests, the #494 pull request also fixes the issue. (However, the #494 fix is ~10% slower, likely due to the internal function definition, in the standard case where no 'left' or 'center' replacements of zero length occur. #494 is ~5% faster in the edge case corrected here, likely due to the internal function returning an empty sting directly instead of snipping to an empty string.)


Below is the summary of the issue:

- when nchar(width) is 1 more than nchar(ellipsis), side 'center' fails to return correct result
- when nchar(width) is == to nchar(ellipsis), sides 'center' and 'left' fail to return correct result

Both cases happen because:
str_sub(string[too_long], -width..., -1))
becomes:
str_sub('characters', 0, -1))
which returns all 'characters' rather than the correct number

Example: 
c('', 'a', 'aa', 'aaa', 'aaaa', 'aaaaaaa') |> str_trunc(3, 'center', "..")

Incorrectly returns: 
[1] ""           "a"          "aa"         "aaa"        "a..aaaa"    "a..aaaaaaa"

Rather than: 
[1] ""    "a"   "aa"  "aaa" "a.." "a.."