### PR TITLE
Fix spelling mistake in split.R

### DIFF
--- a/R/split.R
+++ b/R/split.R
@@ -36,7 +36,7 @@
 #' str_split(fruits, " and ")
 #' str_split(fruits, " and ", simplify = TRUE)
 #'
-#' # If you want to split a single string, use `str_split1`
+#' # If you want to split a single string, use `str_split_1`
 #' str_split_1(fruits[[1]], " and ")
 #'
 #' # Specify n to restrict the number of possible matches

--- a/man/str_split.Rd
+++ b/man/str_split.Rd
@@ -80,7 +80,7 @@ fruits <- c(
 str_split(fruits, " and ")
 str_split(fruits, " and ", simplify = TRUE)
 
-# If you want to split a single string, use `str_split1`
+# If you want to split a single string, use `str_split_1`
 str_split_1(fruits[[1]], " and ")
 
 # Specify n to restrict the number of possible matches


### PR DESCRIPTION
Spelling mistake : correction of the function name from "str_split1" to "str_split_1" in the documentation (split.R file)