### PR TITLE
Fix warning in vignette

### DIFF
--- a/vignettes/from-base.Rmd
+++ b/vignettes/from-base.Rmd
@@ -58,7 +58,10 @@ data_stringr_base_diff <- tibble::tribble(
 
 # create MD table, arranged alphabetically by stringr fn name
 data_stringr_base_diff %>%
-  dplyr::mutate(dplyr::across(.fns = ~ paste0("`", .x, "`"))) %>%
+  dplyr::mutate(dplyr::across(
+      .cols = everything(),
+      .fns = ~ paste0("`", .x, "`"))
+  ) %>%
   dplyr::arrange(stringr) %>%
   dplyr::rename(`base R` = base_r) %>%
   gt::gt() %>%


### PR DESCRIPTION
Fix warning by `dplyr::across()` about missing `.cols` arg.

Currently, there's unwanted warning output included in the [rendered vignette](https://stringr.tidyverse.org/articles/from-base.html#overall-differences). This PR fixes this.