### PR TITLE
add sep argument to str_dup

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # stringr (development version)
 
+* Add sep argument to `str_dup()` (@edward-burn, #564).
+
 * In `str_replace_all()`, a `replacement` function now receives all values in
   a single vector. This radically improves performance at the cost of breaking
   some existing uses (#462).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # stringr (development version)
 
-* Add sep argument to `str_dup()` (@edward-burn, #564).
+* Add sep argument to `str_dup()` so that it is possible to repeat a string and 
+  add a separator between every repeated value. (@edward-burn, #564).
 
 * In `str_replace_all()`, a `replacement` function now receives all values in
   a single vector. This radically improves performance at the cost of breaking

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # stringr (development version)
 
-* Add sep argument to `str_dup()` so that it is possible to repeat a string and 
-  add a separator between every repeated value. (@edward-burn, #564).
+* Add `sep` argument to `str_dup()` so that it is possible to repeat a string and 
+  add a separator between every repeated value (@edward-burn, #564).
 
 * In `str_replace_all()`, a `replacement` function now receives all values in
   a single vector. This radically improves performance at the cost of breaking

--- a/R/dup.R
+++ b/R/dup.R
@@ -11,6 +11,7 @@
 #' @examples
 #' fruit <- c("apple", "pear", "banana")
 #' str_dup(fruit, 2)
+#' str_dup(fruit, 2, sep = " ")
 #' str_dup(fruit, 1:3)
 #' str_c("ba", str_dup("na", 0:5))
 str_dup <- function(string, times, sep = NULL) {
@@ -21,7 +22,7 @@ str_dup <- function(string, times, sep = NULL) {
     stri_dup(input$string, input$times)
   } else {
     map_chr(seq_along(input$string), function(i) {
-      paste(rep(string[i], input$times[i]), collapse = sep)
+      paste(rep(string[[i]], input$times[[i]]), collapse = sep)
     })
   }
 }

--- a/R/dup.R
+++ b/R/dup.R
@@ -14,22 +14,14 @@
 #' str_dup(fruit, 1:3)
 #' str_c("ba", str_dup("na", 0:5))
 str_dup <- function(string, times, sep = NULL) {
-  vctrs::vec_size_common(string = string, times = times)
+  input <- vctrs::vec_recycle_common(string = string, times = times)
+  check_string(sep, allow_null = TRUE)
+
   if (is.null(sep)) {
-    stri_dup(string, times)
+    stri_dup(input$string, input$times)
   } else {
-    # stri_dup does not currently support sep
-    check_string(sep)
-    lapply(seq_along(string), function(i) {
-      if (vctrs::vec_size(times) == 1) {
-        paste(rep(string[i], times), collapse = sep)
-      } else {
-        paste(rep(string[i], times[i]), collapse = sep)
-      }
-    }) %>%
-      rlang::flatten_chr()
+    map_chr(seq_along(input$string), function(i) {
+      paste(rep(string[i], input$times[i]), collapse = sep)
+    })
   }
-
 }
-
-

--- a/R/dup.R
+++ b/R/dup.R
@@ -14,20 +14,22 @@
 #' str_dup(fruit, 1:3)
 #' str_c("ba", str_dup("na", 0:5))
 str_dup <- function(string, times, sep = NULL) {
-  vctrs::vec_size_common(string = string, times = times)
-  if(is.null(sep)){
+  size <- vctrs::vec_size_common(string = string, times = times)
+  if (is.null(sep)) {
     stri_dup(string, times)
   } else {
-  # stri_dup does not currently support sep
-  check_string(sep)
-  lapply(seq_along(string), function(i) {
-    if (length(times) == 1) {
-      paste(rep(string[i], times), collapse = sep)
-    } else {
-      paste(rep(string[i], times[i]), collapse = sep)
-    }
-  }) %>%
-    rlang::flatten_chr()
+    # stri_dup does not currently support sep
+    check_string(sep)
+    lapply(seq_along(string), function(i) {
+      if (size == 1) {
+        paste(rep(string[i], times), collapse = sep)
+      } else {
+        paste(rep(string[i], times[i]), collapse = sep)
+      }
+    }) %>%
+      rlang::flatten_chr()
   }
 
 }
+
+

--- a/R/dup.R
+++ b/R/dup.R
@@ -14,14 +14,14 @@
 #' str_dup(fruit, 1:3)
 #' str_c("ba", str_dup("na", 0:5))
 str_dup <- function(string, times, sep = NULL) {
-  size <- vctrs::vec_size_common(string = string, times = times)
+  vctrs::vec_size_common(string = string, times = times)
   if (is.null(sep)) {
     stri_dup(string, times)
   } else {
     # stri_dup does not currently support sep
     check_string(sep)
     lapply(seq_along(string), function(i) {
-      if (size == 1) {
+      if (vctrs::vec_size(times) == 1) {
         paste(rep(string[i], times), collapse = sep)
       } else {
         paste(rep(string[i], times[i]), collapse = sep)

--- a/R/dup.R
+++ b/R/dup.R
@@ -5,6 +5,7 @@
 #'
 #' @inheritParams str_detect
 #' @param times Number of times to duplicate each string.
+#' @param sep String to insert between each duplicate.
 #' @return A character vector the same length as `string`/`times`.
 #' @export
 #' @examples
@@ -12,7 +13,21 @@
 #' str_dup(fruit, 2)
 #' str_dup(fruit, 1:3)
 #' str_c("ba", str_dup("na", 0:5))
-str_dup <- function(string, times) {
+str_dup <- function(string, times, sep = NULL) {
   vctrs::vec_size_common(string = string, times = times)
-  stri_dup(string, times)
+  if(is.null(sep)){
+    stri_dup(string, times)
+  } else {
+  # stri_dup does not currently support sep
+  check_string(sep)
+  lapply(seq_along(string), function(i) {
+    if (length(times) == 1) {
+      paste(rep(string[i], times), collapse = sep)
+    } else {
+      paste(rep(string[i], times[i]), collapse = sep)
+    }
+  }) |>
+    rlang::flatten_chr()
+  }
+
 }

--- a/R/dup.R
+++ b/R/dup.R
@@ -26,7 +26,7 @@ str_dup <- function(string, times, sep = NULL) {
     } else {
       paste(rep(string[i], times[i]), collapse = sep)
     }
-  }) |>
+  }) %>%
     rlang::flatten_chr()
   }
 

--- a/man/str_dup.Rd
+++ b/man/str_dup.Rd
@@ -24,6 +24,7 @@ A character vector the same length as \code{string}/\code{times}.
 \examples{
 fruit <- c("apple", "pear", "banana")
 str_dup(fruit, 2)
+str_dup(fruit, 2, sep = " ")
 str_dup(fruit, 1:3)
 str_c("ba", str_dup("na", 0:5))
 }

--- a/man/str_dup.Rd
+++ b/man/str_dup.Rd
@@ -4,13 +4,15 @@
 \alias{str_dup}
 \title{Duplicate a string}
 \usage{
-str_dup(string, times)
+str_dup(string, times, sep = NULL)
 }
 \arguments{
 \item{string}{Input vector. Either a character vector, or something
 coercible to one.}
 
 \item{times}{Number of times to duplicate each string.}
+
+\item{sep}{String to insert between each duplicate.}
 }
 \value{
 A character vector the same length as \code{string}/\code{times}.

--- a/tests/testthat/_snaps/dup.md
+++ b/tests/testthat/_snaps/dup.md
@@ -4,7 +4,7 @@
       str_dup("a", 3, sep = 1)
     Condition
       Error in `str_dup()`:
-      ! `sep` must be a single string, not the number 1.
+      ! `sep` must be a single string or `NULL`, not the number 1.
 
 ---
 
@@ -12,7 +12,7 @@
       str_dup("a", 3, sep = c("-", ";"))
     Condition
       Error in `str_dup()`:
-      ! `sep` must be a single string, not a character vector.
+      ! `sep` must be a single string or `NULL`, not a character vector.
 
 ---
 

--- a/tests/testthat/_snaps/dup.md
+++ b/tests/testthat/_snaps/dup.md
@@ -1,0 +1,32 @@
+# uses sep argument
+
+    Code
+      str_dup("a", 3, sep = 1)
+    Condition
+      Error in `str_dup()`:
+      ! `sep` must be a single string, not the number 1.
+
+---
+
+    Code
+      str_dup("a", 3, sep = c("-", ";"))
+    Condition
+      Error in `str_dup()`:
+      ! `sep` must be a single string, not a character vector.
+
+---
+
+    Code
+      str_dup(c("aa", "bb"), c(2, 3, 4), sep = ";")
+    Condition
+      Error in `str_dup()`:
+      ! Can't recycle `string` (size 2) to match `times` (size 3).
+
+---
+
+    Code
+      str_dup(c("aa", "bb", "cc"), c(2, 3), sep = ";")
+    Condition
+      Error in `str_dup()`:
+      ! Can't recycle `string` (size 3) to match `times` (size 2).
+

--- a/tests/testthat/_snaps/dup.md
+++ b/tests/testthat/_snaps/dup.md
@@ -1,32 +1,13 @@
-# uses sep argument
+# separator must be a single string
 
     Code
       str_dup("a", 3, sep = 1)
     Condition
       Error in `str_dup()`:
       ! `sep` must be a single string or `NULL`, not the number 1.
-
----
-
     Code
       str_dup("a", 3, sep = c("-", ";"))
     Condition
       Error in `str_dup()`:
       ! `sep` must be a single string or `NULL`, not a character vector.
-
----
-
-    Code
-      str_dup(c("aa", "bb"), c(2, 3, 4), sep = ";")
-    Condition
-      Error in `str_dup()`:
-      ! Can't recycle `string` (size 2) to match `times` (size 3).
-
----
-
-    Code
-      str_dup(c("aa", "bb", "cc"), c(2, 3), sep = ";")
-    Condition
-      Error in `str_dup()`:
-      ! Can't recycle `string` (size 3) to match `times` (size 2).
 

--- a/tests/testthat/test-dup.R
+++ b/tests/testthat/test-dup.R
@@ -15,17 +15,19 @@ test_that("uses tidyverse recycling rules", {
 })
 
 test_that("uses sep argument", {
+  expect_equal(str_dup("abc", 1, sep = "-"), "abc")
   expect_equal(str_dup("abc", 2, sep = "-"), "abc-abc")
-  expect_equal(str_dup(c("a", "b"), 2, sep = "x"), c("axa", "bxb"))
-  expect_equal(str_dup(c("aa", "bb", "ccc"), c(2, 3, 4), sep = ";"),
-               c("aa;aa", "bb;bb;bb", "ccc;ccc;ccc;ccc"))
 
-  expect_identical(character(), str_dup(character(), 1, sep = ":"))
+  expect_equal(str_dup(c("a", "b"), 2, sep = "-"), c("a-a", "b-b"))
+  expect_equal(str_dup(c("a", "b"), c(1, 2), sep = "-"), c("a", "b-b"))
 
-  expect_snapshot(str_dup("a", 3, sep = 1), error = TRUE)
-  expect_snapshot(str_dup("a", 3, sep = c("-", ";")), error = TRUE)
-  expect_snapshot(str_dup(c("aa", "bb"), c(2, 3, 4), sep = ";"), error = TRUE)
-  expect_snapshot(str_dup(c("aa", "bb", "cc"), c(2, 3), sep = ";"), error = TRUE)
-
+  expect_equal(str_dup(character(), 1, sep = ":"), character())
+  expect_equal(str_dup(character(), 2, sep = ":"), character())
 })
 
+test_that("separator must be a single string", {
+  expect_snapshot(error = TRUE, {
+    str_dup("a", 3, sep = 1)
+    str_dup("a", 3, sep = c("-", ";"))
+  })
+})

--- a/tests/testthat/test-dup.R
+++ b/tests/testthat/test-dup.R
@@ -13,3 +13,20 @@ test_that("0 duplicates equals empty string", {
 test_that("uses tidyverse recycling rules", {
   expect_error(str_dup(1:2, 1:3), class = "vctrs_error_incompatible_size")
 })
+
+test_that("uses sep argument", {
+  expect_equal(str_dup("a", 3, sep = ";"), "a;a;a")
+  expect_equal(str_dup("abc", 2, sep = "-"), "abc-abc")
+  expect_equal(str_dup("a", 3, sep = ";"), "a;a;a")
+  expect_equal(str_dup("abc", 2, sep = "-"), "abc-abc")
+  expect_equal(str_dup(c("a", "b"), 2, sep = "x"), c("axa", "bxb"))
+  expect_equal(str_dup(c("aa", "bb", "ccc"), c(2, 3, 4), sep = ";"),
+               c("aa;aa", "bb;bb;bb", "ccc;ccc;ccc;ccc"))
+
+  expect_error(str_dup("a", 3, sep = 1))
+  expect_error(str_dup("a", 3, sep = c("-", ";")))
+  expect_error(str_dup(c("aa", "bb"), c(2, 3, 4), sep = ";"))
+  expect_error(str_dup(c("aa", "bb", "cc"), c(2, 3), sep = ";"))
+
+})
+

--- a/tests/testthat/test-dup.R
+++ b/tests/testthat/test-dup.R
@@ -21,8 +21,8 @@ test_that("uses sep argument", {
   expect_equal(str_dup(c("a", "b"), 2, sep = "-"), c("a-a", "b-b"))
   expect_equal(str_dup(c("a", "b"), c(1, 2), sep = "-"), c("a", "b-b"))
 
-  expect_equal(str_dup(character(), 1, sep = ":"), character())
-  expect_equal(str_dup(character(), 2, sep = ":"), character())
+  expect_equal(str_dup(character(), 1, sep = "-"), character())
+  expect_equal(str_dup(character(), 2, sep = "-"), character())
 })
 
 test_that("separator must be a single string", {

--- a/tests/testthat/test-dup.R
+++ b/tests/testthat/test-dup.R
@@ -15,18 +15,17 @@ test_that("uses tidyverse recycling rules", {
 })
 
 test_that("uses sep argument", {
-  expect_equal(str_dup("a", 3, sep = ";"), "a;a;a")
-  expect_equal(str_dup("abc", 2, sep = "-"), "abc-abc")
-  expect_equal(str_dup("a", 3, sep = ";"), "a;a;a")
   expect_equal(str_dup("abc", 2, sep = "-"), "abc-abc")
   expect_equal(str_dup(c("a", "b"), 2, sep = "x"), c("axa", "bxb"))
   expect_equal(str_dup(c("aa", "bb", "ccc"), c(2, 3, 4), sep = ";"),
                c("aa;aa", "bb;bb;bb", "ccc;ccc;ccc;ccc"))
 
-  expect_error(str_dup("a", 3, sep = 1))
-  expect_error(str_dup("a", 3, sep = c("-", ";")))
-  expect_error(str_dup(c("aa", "bb"), c(2, 3, 4), sep = ";"))
-  expect_error(str_dup(c("aa", "bb", "cc"), c(2, 3), sep = ";"))
+  expect_identical(character(), str_dup(character(), 1, sep = ":"))
+
+  expect_snapshot(str_dup("a", 3, sep = 1), error = TRUE)
+  expect_snapshot(str_dup("a", 3, sep = c("-", ";")), error = TRUE)
+  expect_snapshot(str_dup(c("aa", "bb"), c(2, 3, 4), sep = ";"), error = TRUE)
+  expect_snapshot(str_dup(c("aa", "bb", "cc"), c(2, 3), sep = ";"), error = TRUE)
 
 })
 


### PR DESCRIPTION
closes #487

Adds a sep argument to str_dup. Becasue this is not supported by stri_dup, do separately and use lapply to go through strings.