### PR TITLE
translate error messages ES:

### DIFF
--- a/po/R-es.po
+++ b/po/R-es.po
@@ -2,13 +2,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: stringr 1.5.1.9000\n"
 "POT-Creation-Date: 2024-08-15 10:19-0700\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
+"PO-Revision-Date: 2024-08-15 10:19-0700\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: detect.R:141
 msgid "{.arg pattern} must be a plain string, not a stringr modifier."
@@ -36,7 +37,7 @@ msgstr ""
 
 #: replace.R:209
 msgid "It must accept a character vector of any length."
-msgstr ""
+msgstr "Debe aceptar un vector de caracteres de cualquier longitud."
 
 #: replace.R:220
 msgid ""
@@ -46,13 +47,13 @@ msgstr ""
 
 #: replace.R:226
 msgid ""
-"{.arg replacement} function must return a vector the same length as the "
-"input ({length(old_flat)}), not length {length(new_flat)}."
+"{.arg replacement} function must return a vector the same length as the input "
+"({length(old_flat)}), not length {length(new_flat)}."
 msgstr ""
 
 #: split.R:122
 msgid "{.arg i} must not be 0."
-msgstr ""
+msgstr "{.arg i} no debe ser igual a 0."
 
 #: trunc.R:32
 msgid "`width` ({width}) is shorter than `ellipsis` ({str_length(ellipsis)})."
@@ -64,4 +65,4 @@ msgstr ""
 
 #: utils.R:26
 msgid "{.arg pattern} can't be the empty string ({.code \"\"})."
-msgstr ""
+msgstr "{.arg pattern} no puede ser una cadena de caracteres vacia ({.code \"\"})."


### PR DESCRIPTION
Part of https://github.com/tidyverse/stringr/issues/556

#: replace.R:209
#: split.R:122
#: utils.R:26

about _input_ translation: [Translation (or not) of technical terms in Spanish.](https://github.com/cienciadedatos/documentacion-traduccion-r4ds/blob/master/orientaciones-traduccion.md#ii-traducci%C3%B3n-o-no-de-t%C3%A9rminos-t%C3%A9cnicos)