### PR TITLE
Fix typo in code description

### DIFF
--- a/R/match.R
+++ b/R/match.R
@@ -18,7 +18,7 @@
 #'   if you used "named captured groups", i.e. `(?<name>pattern')`.
 #'
 #' * `str_match_all()`: a list of the same length as `string`/`pattern`
-#'   containing character matrices. Each matrix has columns as descrbed above
+#'   containing character matrices. Each matrix has columns as described above
 #'   and one row for each match.
 #'
 #' @seealso [str_extract()] to extract the complete match,

--- a/man/str_match.Rd
+++ b/man/str_match.Rd
@@ -24,7 +24,7 @@ length of \code{string}/\code{pattern}. The first column is the complete match,
 followed by one column for each capture group. The columns will be named
 if you used "named captured groups", i.e. \verb{(?<name>pattern')}.
 \item \code{str_match_all()}: a list of the same length as \code{string}/\code{pattern}
-containing character matrices. Each matrix has columns as descrbed above
+containing character matrices. Each matrix has columns as described above
 and one row for each match.
 }
 }


### PR DESCRIPTION
Hi `stringr` maintainers 👋
I've noticed a simple typo in the description of the function but haven't run roxygen on it.