### PR TITLE
Preserve names where sensible

### DIFF
--- a/R/case.R
+++ b/R/case.R
@@ -28,29 +28,37 @@ NULL
 str_to_upper <- function(string, locale = "en") {
   check_string(locale)
 
-  stri_trans_toupper(string, locale = locale)
+  out <- stri_trans_toupper(string, locale = locale)
+  if (length(out) == length(string)) names(out) <- names(string)
+  out
 }
 #' @export
 #' @rdname case
 str_to_lower <- function(string, locale = "en") {
   check_string(locale)
 
-  stri_trans_tolower(string, locale = locale)
+  out <- stri_trans_tolower(string, locale = locale)
+  if (length(out) == length(string)) names(out) <- names(string)
+  out
 }
 #' @export
 #' @rdname case
 str_to_title <- function(string, locale = "en") {
   check_string(locale)
 
-  stri_trans_totitle(string, opts_brkiter = stri_opts_brkiter(locale = locale))
+  out <- stri_trans_totitle(string, opts_brkiter = stri_opts_brkiter(locale = locale))
+  if (length(out) == length(string)) names(out) <- names(string)
+  out
 }
 #' @export
 #' @rdname case
 str_to_sentence <- function(string, locale = "en") {
   check_string(locale)
 
-  stri_trans_totitle(
+  out <- stri_trans_totitle(
     string,
     opts_brkiter = stri_opts_brkiter(type = "sentence", locale = locale)
   )
+  if (length(out) == length(string)) names(out) <- names(string)
+  out
 }

--- a/R/conv.R
+++ b/R/conv.R
@@ -15,5 +15,7 @@
 str_conv <- function(string, encoding) {
   check_string(encoding)
 
-  stri_conv(string, encoding, "UTF-8")
+  out <- stri_conv(string, encoding, "UTF-8")
+  if (length(out) == length(string)) names(out) <- names(string)
+  out
 }

--- a/R/count.R
+++ b/R/count.R
@@ -37,11 +37,13 @@
 str_count <- function(string, pattern = "") {
   check_lengths(string, pattern)
 
-  switch(type(pattern),
+  out <- switch(type(pattern),
     empty = ,
     bound = stri_count_boundaries(string, opts_brkiter = opts(pattern)),
     fixed = stri_count_fixed(string, pattern, opts_fixed = opts(pattern)),
     coll  = stri_count_coll(string, pattern, opts_collator = opts(pattern)),
     regex = stri_count_regex(string, pattern, opts_regex = opts(pattern))
   )
+  if (length(out) == length(string)) names(out) <- names(string)
+  out
 }

--- a/R/detect.R
+++ b/R/detect.R
@@ -42,13 +42,19 @@ str_detect <- function(string, pattern, negate = FALSE) {
   check_lengths(string, pattern)
   check_bool(negate)
 
-  switch(type(pattern),
+  out <- switch(type(pattern),
     empty = no_empty(),
     bound = no_boundary(),
     fixed = stri_detect_fixed(string, pattern, negate = negate, opts_fixed = opts(pattern)),
     coll  = stri_detect_coll(string,  pattern, negate = negate, opts_collator = opts(pattern)),
     regex = stri_detect_regex(string, pattern, negate = negate, opts_regex = opts(pattern))
   )
+
+  # Preserve names when there's a 1:1 correspondence with `string`
+  if (length(out) == length(string)) {
+    names(out) <- names(string)
+  }
+  out
 }
 
 #' Detect the presence/absence of a match at the start/end
@@ -78,7 +84,7 @@ str_starts <- function(string, pattern, negate = FALSE) {
   check_lengths(string, pattern)
   check_bool(negate)
 
-  switch(type(pattern),
+  out <- switch(type(pattern),
     empty = no_empty(),
     bound = no_boundary(),
     fixed = stri_startswith_fixed(string, pattern, negate = negate, opts_fixed = opts(pattern)),
@@ -88,6 +94,8 @@ str_starts <- function(string, pattern, negate = FALSE) {
       stri_detect_regex(string, pattern2, negate = negate, opts_regex = opts(pattern))
     }
   )
+  if (length(out) == length(string)) names(out) <- names(string)
+  out
 }
 
 #' @rdname str_starts
@@ -96,7 +104,7 @@ str_ends <- function(string, pattern, negate = FALSE) {
   check_lengths(string, pattern)
   check_bool(negate)
 
-  switch(type(pattern),
+  out <- switch(type(pattern),
     empty = no_empty(),
     bound = no_boundary(),
     fixed = stri_endswith_fixed(string, pattern, negate = negate, opts_fixed = opts(pattern)),
@@ -106,6 +114,8 @@ str_ends <- function(string, pattern, negate = FALSE) {
       stri_detect_regex(string, pattern2, negate = negate, opts_regex = opts(pattern))
     }
   )
+  if (length(out) == length(string)) names(out) <- names(string)
+  out
 }
 
 #' Detect a pattern in the same way as `SQL`'s `LIKE` and `ILIKE` operators
@@ -166,7 +176,9 @@ str_like <- function(string, pattern, ignore_case = deprecated()) {
   }
 
   pattern <- regex(like_to_regex(pattern), ignore_case = FALSE)
-  stri_detect_regex(string, pattern, opts_regex = opts(pattern))
+  out <- stri_detect_regex(string, pattern, opts_regex = opts(pattern))
+  if (length(out) == length(string)) names(out) <- names(string)
+  out
 }
 
 #' @export
@@ -179,7 +191,9 @@ str_ilike <- function(string, pattern) {
   }
 
   pattern <- regex(like_to_regex(pattern), ignore_case = TRUE)
-  stri_detect_regex(string, pattern, opts_regex = opts(pattern))
+  out <- stri_detect_regex(string, pattern, opts_regex = opts(pattern))
+  if (length(out) == length(string)) names(out) <- names(string)
+  out
 }
 
 like_to_regex <- function(pattern) {

--- a/R/dup.R
+++ b/R/dup.R
@@ -19,10 +19,12 @@ str_dup <- function(string, times, sep = NULL) {
   check_string(sep, allow_null = TRUE)
 
   if (is.null(sep)) {
-    stri_dup(input$string, input$times)
+    out <- stri_dup(input$string, input$times)
   } else {
-    map_chr(seq_along(input$string), function(i) {
+    out <- map_chr(seq_along(input$string), function(i) {
       paste(rep(string[[i]], input$times[[i]]), collapse = sep)
     })
   }
+  if (length(out) == length(input$string)) names(out) <- names(input$string)
+  out
 }

--- a/R/escape.R
+++ b/R/escape.R
@@ -12,5 +12,7 @@
 #' str_detect(c("a", "."), ".")
 #' str_detect(c("a", "."), str_escape("."))
 str_escape <- function(string) {
-  str_replace_all(string, "([.^$\\\\|*+?{}\\[\\]()])", "\\\\\\1")
+  out <- str_replace_all(string, "([.^$\\\\|*+?{}\\[\\]()])", "\\\\\\1")
+  if (length(out) == length(string)) names(out) <- names(string)
+  out
 }

--- a/R/extract.R
+++ b/R/extract.R
@@ -40,17 +40,21 @@
 #' str_extract_all("This is, suprisingly, a sentence.", boundary("word"))
 str_extract <- function(string, pattern, group = NULL) {
   if (!is.null(group)) {
-    return(str_match(string, pattern)[, group + 1])
+    out <- str_match(string, pattern)[, group + 1]
+    if (length(out) == length(string)) names(out) <- names(string)
+    return(out)
   }
 
   check_lengths(string, pattern)
-  switch(type(pattern),
+  out <- switch(type(pattern),
     empty = stri_extract_first_boundaries(string, opts_brkiter = opts(pattern)),
     bound = stri_extract_first_boundaries(string, opts_brkiter = opts(pattern)),
     fixed = stri_extract_first_fixed(string, pattern, opts_fixed = opts(pattern)),
     coll  = stri_extract_first_coll(string, pattern, opts_collator = opts(pattern)),
     regex = stri_extract_first_regex(string, pattern, opts_regex = opts(pattern))
   )
+  if (length(out) == length(string)) names(out) <- names(string)
+  out
 }
 
 #' @rdname str_extract
@@ -59,7 +63,7 @@ str_extract_all <- function(string, pattern, simplify = FALSE) {
   check_lengths(string, pattern)
   check_bool(simplify)
 
-  switch(type(pattern),
+  out <- switch(type(pattern),
     empty = stri_extract_all_boundaries(string,
       simplify = simplify, omit_no_match = TRUE, opts_brkiter = opts(pattern)),
     bound = stri_extract_all_boundaries(string,
@@ -71,4 +75,10 @@ str_extract_all <- function(string, pattern, simplify = FALSE) {
     regex = stri_extract_all_regex(string, pattern,
       simplify = simplify, omit_no_match = TRUE, opts_regex = opts(pattern))
   )
+  if (isTRUE(simplify)) {
+    if (is.matrix(out) && nrow(out) == length(string)) rownames(out) <- names(string)
+  } else {
+    if (is.list(out) && length(out) == length(string)) names(out) <- names(string)
+  }
+  out
 }

--- a/R/length.R
+++ b/R/length.R
@@ -34,11 +34,15 @@
 #' # Because the second element is made up of a u + an accent
 #' str_sub(u, 1, 1)
 str_length <- function(string) {
-  stri_length(string)
+  out <- stri_length(string)
+  if (length(out) == length(string)) names(out) <- names(string)
+  out
 }
 
 #' @export
 #' @rdname str_length
 str_width <- function(string) {
-  stri_width(string)
+  out <- stri_width(string)
+  if (length(out) == length(string)) names(out) <- names(string)
+  out
 }

--- a/R/locate.R
+++ b/R/locate.R
@@ -37,13 +37,15 @@
 str_locate <- function(string, pattern) {
   check_lengths(string, pattern)
 
-  switch(type(pattern),
+  out <- switch(type(pattern),
     empty = ,
     bound = stri_locate_first_boundaries(string, opts_brkiter = opts(pattern)),
     fixed = stri_locate_first_fixed(string, pattern, opts_fixed = opts(pattern)),
     coll  = stri_locate_first_coll(string, pattern, opts_collator = opts(pattern)),
     regex = stri_locate_first_regex(string, pattern, opts_regex = opts(pattern))
   )
+  if (is.matrix(out) && nrow(out) == length(string)) rownames(out) <- names(string)
+  out
 }
 
 #' @rdname str_locate
@@ -52,13 +54,15 @@ str_locate_all <- function(string, pattern) {
   check_lengths(string, pattern)
   opts <- opts(pattern)
 
-  switch(type(pattern),
+  out <- switch(type(pattern),
     empty = ,
     bound = stri_locate_all_boundaries(string, omit_no_match = TRUE, opts_brkiter = opts),
     fixed = stri_locate_all_fixed(string, pattern, omit_no_match = TRUE, opts_fixed = opts),
     regex = stri_locate_all_regex(string, pattern, omit_no_match = TRUE, opts_regex = opts),
     coll  = stri_locate_all_coll(string, pattern, omit_no_match = TRUE, opts_collator = opts)
   )
+  if (is.list(out) && length(out) == length(string)) names(out) <- names(string)
+  out
 }
 
 

--- a/R/match.R
+++ b/R/match.R
@@ -54,10 +54,12 @@ str_match <- function(string, pattern) {
     cli::cli_abort(tr_("{.arg pattern} must be a regular expression."))
   }
 
-  stri_match_first_regex(string,
+  out <- stri_match_first_regex(string,
     pattern,
     opts_regex = opts(pattern)
   )
+  if (is.matrix(out) && nrow(out) == length(string)) rownames(out) <- names(string)
+  out
 }
 
 #' @rdname str_match
@@ -68,9 +70,11 @@ str_match_all <- function(string, pattern) {
     cli::cli_abort(tr_("{.arg pattern} must be a regular expression."))
   }
 
-  stri_match_all_regex(string,
+  out <- stri_match_all_regex(string,
     pattern,
     omit_no_match = TRUE,
     opts_regex = opts(pattern)
   )
+  if (is.list(out) && length(out) == length(string)) names(out) <- names(string)
+  out
 }

--- a/R/pad.R
+++ b/R/pad.R
@@ -32,9 +32,11 @@ str_pad <- function(string, width, side = c("left", "right", "both"), pad = " ",
   side <- arg_match(side)
   check_bool(use_width)
 
-  switch(side,
+  out <- switch(side,
     left = stri_pad_left(string, width, pad = pad, use_length = !use_width),
     right = stri_pad_right(string, width, pad = pad, use_length = !use_width),
     both = stri_pad_both(string, width, pad = pad, use_length = !use_width)
   )
+  if (length(out) == length(string)) names(out) <- names(string)
+  out
 }

--- a/R/replace.R
+++ b/R/replace.R
@@ -76,7 +76,7 @@ str_replace <- function(string, pattern, replacement) {
 
   check_lengths(string, pattern, replacement)
 
-  switch(type(pattern),
+  out <- switch(type(pattern),
     empty = no_empty(),
     bound = no_boundary(),
     fixed = stri_replace_first_fixed(string, pattern, replacement,
@@ -86,6 +86,8 @@ str_replace <- function(string, pattern, replacement) {
     regex = stri_replace_first_regex(string, pattern, fix_replacement(replacement),
       opts_regex = opts(pattern))
   )
+  if (length(out) == length(string)) names(out) <- names(string)
+  out
 }
 
 #' @export
@@ -107,7 +109,7 @@ str_replace_all <- function(string, pattern, replacement) {
   }
 
 
-  switch(type(pattern),
+  out <- switch(type(pattern),
     empty = no_empty(),
     bound = no_boundary(),
     fixed = stri_replace_all_fixed(string, pattern, replacement,
@@ -117,6 +119,8 @@ str_replace_all <- function(string, pattern, replacement) {
     regex = stri_replace_all_regex(string, pattern, fix_replacement(replacement),
       vectorize_all = vec, opts_regex = opts(pattern))
   )
+  if (length(out) == length(string)) names(out) <- names(string)
+  out
 }
 
 is_replacement_fun <- function(x) {
@@ -178,7 +182,9 @@ fix_replacement_one <- function(x) {
 #' str_replace_na(c(NA, "abc", "def"))
 str_replace_na <- function(string, replacement = "NA") {
   check_string(replacement)
-  stri_replace_na(string, replacement)
+  out <- stri_replace_na(string, replacement)
+  if (length(out) == length(string)) names(out) <- names(string)
+  out
 }
 
 

--- a/R/sort.R
+++ b/R/sort.R
@@ -86,10 +86,13 @@ str_sort <- function(x,
   check_string(locale)
   check_bool(numeric)
 
+  # Order + subset to preserve names (like base::sort)
   opts <- stri_opts_collator(locale, numeric = numeric, ...)
-  stri_sort(x,
+  idx <- stri_order(
+    x,
     decreasing = decreasing,
     na_last = na_last,
     opts_collator = opts
   )
+  x[idx]
 }

--- a/R/sub.R
+++ b/R/sub.R
@@ -64,11 +64,13 @@
 str_sub <- function(string, start = 1L, end = -1L) {
   vctrs::vec_size_common(string = string, start = start, end = end)
 
-  if (is.matrix(start)) {
+  out <- if (is.matrix(start)) {
     stri_sub(string, from = start)
   } else {
     stri_sub(string, from = start, to = end)
   }
+  if (length(out) == length(string)) names(out) <- names(string)
+  out
 }
 
 
@@ -88,9 +90,11 @@ str_sub <- function(string, start = 1L, end = -1L) {
 #' @export
 #' @rdname str_sub
 str_sub_all <- function(string, start = 1L, end = -1L) {
-  if (is.matrix(start)) {
+  out <- if (is.matrix(start)) {
     stri_sub_all(string, from = start)
   } else {
     stri_sub_all(string, from = start, to = end)
   }
+  if (is.list(out) && length(out) == length(string)) names(out) <- names(string)
+  out
 }

--- a/R/trim.R
+++ b/R/trim.R
@@ -19,15 +19,19 @@
 str_trim <- function(string, side = c("both", "left", "right")) {
   side <- arg_match(side)
 
-  switch(side,
+  out <- switch(side,
     left =  stri_trim_left(string),
     right = stri_trim_right(string),
     both =  stri_trim_both(string)
   )
+  if (length(out) == length(string)) names(out) <- names(string)
+  out
 }
 
 #' @export
 #' @rdname str_trim
 str_squish <- function(string) {
-  stri_trim_both(str_replace_all(string, "\\s+", " "))
+  out <- stri_trim_both(str_replace_all(string, "\\s+", " "))
+  if (length(out) == length(string)) names(out) <- names(string)
+  out
 }

--- a/R/unique.R
+++ b/R/unique.R
@@ -26,5 +26,11 @@ str_unique <- function(string, locale = "en", ignore_case = FALSE, ...) {
     ignore_case = ignore_case,
     ...
   )
-  stri_unique(string, opts_collator = opts)
+  out <- stri_unique(string, opts_collator = opts)
+  # Preserve names of first occurrence for each unique value
+  if (!is.null(names(string))) {
+    idx <- match(out, string)
+    names(out) <- names(string)[idx]
+  }
+  out
 }

--- a/R/word.R
+++ b/R/word.R
@@ -52,5 +52,7 @@ word <- function(string, start = 1L, end = start, sep = fixed(" ")) {
   starts <- mapply(function(word, loc) word[loc, "start"], words, start)
   ends <-   mapply(function(word, loc) word[loc, "end"], words, end)
 
-  str_sub(string, starts, ends)
+  out <- str_sub(string, starts, ends)
+  if (length(out) == length(string)) names(out) <- names(string)
+  out
 }

--- a/R/wrap.R
+++ b/R/wrap.R
@@ -39,5 +39,7 @@ str_wrap <- function(string,
 
   out <- stri_wrap(string, width = width, indent = indent, exdent = exdent,
     whitespace_only = whitespace_only, simplify = FALSE)
-  vapply(out, str_c, collapse = "\n", character(1))
+  out <- vapply(out, str_c, collapse = "\n", character(1))
+  if (length(out) == length(string)) names(out) <- names(string)
+  out
 }

--- a/tests/testthat/test-preserve-names.R
+++ b/tests/testthat/test-preserve-names.R
@@ -1,0 +1,89 @@
+x <- c(C = "3", B = "2", A = "1")
+
+test_that("elementwise logical/numeric functions preserve names", {
+
+  expect_equal(names(str_count(x, ".")), names(x))
+  expect_equal(names(str_detect(x, "[123]")), names(x))
+  expect_equal(names(str_starts(x, "1")), names(x))
+  expect_equal(names(str_ends(x, "1")), names(x))
+  expect_equal(names(str_like(x, "%")), names(x))
+})
+
+test_that("elementwise string transforms preserve names", {
+  expect_equal(names(str_escape(x)), names(x))
+  expect_equal(names(str_replace(x, "[0-9]", "x")), names(x))
+  expect_equal(names(str_replace_all(x, "[0-9]", "x")), names(x))
+  expect_equal(names(str_remove(x, "[0-9]")), names(x))
+  expect_equal(names(str_conv(x, "UTF-8")), names(x))
+  expect_equal(names(str_trim(x)), names(x))
+  expect_equal(names(str_trunc(x, 3)), names(x))
+  expect_equal(names(str_pad(x, 2, side = "left")), names(x))
+  expect_equal(names(str_sub(x, 1, 1)), names(x))
+})
+
+test_that("case conversions preserve names", {
+  expect_equal(names(str_to_lower(x)), names(x))
+  expect_equal(names(str_to_upper(x)), names(x))
+  expect_equal(names(str_to_title(x)), names(x))
+})
+
+test_that("extraction functions preserve names (vector)", {
+  expect_equal(names(str_extract(x, "[0-9]")), names(x))
+})
+
+test_that("location/match matrices preserve row names", {
+  expect_equal(rownames(str_locate(x, "[0-9]")), names(x))
+  expect_equal(rownames(str_match(x, "([0-9])")), names(x))
+})
+
+test_that("list/matrix outputs preserve names on outer structure", {
+  # Lists
+  expect_equal(names(str_extract_all(x, "[0-9]")), names(x))
+  expect_equal(names(str_locate_all(x, "[0-9]")), names(x))
+  expect_equal(names(str_match_all(x, "([0-9])")), names(x))
+  expect_equal(names(str_split(x, "")), names(x))
+  expect_equal(names(str_sub_all(x, 1, 1)), names(x))
+
+  # Matrices (rows correspond to inputs)
+  expect_equal(rownames(str_split(x, "", simplify = TRUE)), names(x))
+  expect_equal(rownames(str_split_fixed(x, "", 1)), names(x))
+})
+
+test_that("length and duplication preserve names", {
+  expect_equal(names(str_length(x)), names(x))
+  expect_equal(names(str_width(x)), names(x))
+  expect_equal(names(str_dup(x, 2)), names(x))
+})
+
+test_that("word() preserves names", {
+  expect_equal(names(word(x, 1)), names(x))
+})
+
+test_that("str_unique() preserves names of first occurrences", {
+  y <- c(A = "a", A2 = "a", B = "b")
+  out <- str_unique(y)
+  expect_equal(names(out), c("A", "B"))
+})
+
+test_that("str_replace_na() preserves names", {
+  y <- c(A = NA, B = "x")
+  expect_equal(names(str_replace_na(y)), names(y))
+})
+
+test_that("str_subset() preserves names of retained elements", {
+  out <- str_subset(x, "[12]")
+  expect_equal(names(out), c("B", "A"))
+})
+
+test_that("str_sort() preserves names", {
+  out <- str_sort(x)
+  expect_equal(names(out), c("A", "B", "C"))
+})
+
+test_that("str_wrap() preserves names", {
+  expect_equal(names(str_wrap(x)), names(x))
+})
+
+test_that("str_split_i() preserves names", {
+  expect_equal(names(str_split_i(x, " ", 1)), names(x))
+})


### PR DESCRIPTION
#575 points out that some stringr functions preserve names, but most don't. This pull request implements preservation of names where there should be no ambiguity.

#575 was closed with a recommendation to take the issue to stringi. I tried, and my pull request gagolews/stringi#521 was rejected as a matter of policy. Hence, I propose that we make this change in stringr. There are situations where preserving names is useful, and str_subset() and str_trunc() currently do that. In the stringi issue gagolews/stringi#59, @hadley argued that names is the only attribute that stringi should preserve.

This pull request makes focused modifications to the functions involved, and adds `tests/testthat/test-preserve-names.R`. All existing and new tests pass, and devtools::check() reports no errors or warnings, only a note which was already in current `main`.

Principles:

- Preserve names where the output has a 1-to-1 correspondence with the input.
- Preserve names for functions where base behavior suggests keeping names (e.g., grepl/grep(value=TRUE), sort/unique).
- Source of names: use names from the primary `string` argument only; ignore names on `pattern`/`replacement`/others and never merge.
- For 1-row-per-input matrices/lists (e.g., str_locate/str_match/str_split_fixed), set row/list names from input names.
- Don't preserve names where strings are combined, or the return values are indices
  (e.g., str_c, str_flatten, str_glue, str_which, str_order, str_equal).

These functions already preserve names:

- str_subset
- str_trunc

These functions preserve names if this pull request is accepted:

- str_count
- str_detect
- str_starts
- str_ends
- str_like
- str_escape
- str_replace
- str_remove
- str_conv
- str_trim
- str_pad
- str_sub
- str_to_lower
- str_to_upper
- str_to_title
- str_extract
- str_locate
- str_match
- str_extract_all
- str_locate_all
- str_match_all
- str_split
- str_split_fixed
- str_split_i
- str_sub_all
- str_length
- str_width
- str_dup
- word
- str_unique
- str_replace_na
- str_sort
- str_wrap
- str_replace_all
