### PR TITLE
Use the base pipe, require R 4.1.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,9 +13,9 @@ Description: A consistent, simple and easy to use set of wrappers around
 License: MIT + file LICENSE
 URL: https://stringr.tidyverse.org, https://github.com/tidyverse/stringr
 BugReports: https://github.com/tidyverse/stringr/issues
-Depends: 
-    R (>= 3.6)
-Imports: 
+Depends:
+    R (>= 4.1)
+Imports:
     cli,
     glue (>= 1.6.1),
     lifecycle (>= 1.0.3),
@@ -23,7 +23,7 @@ Imports:
     rlang (>= 1.0.0),
     stringi (>= 1.5.3),
     vctrs (>= 0.4.0)
-Suggests: 
+Suggests:
     covr,
     dplyr,
     gt,
@@ -33,7 +33,7 @@ Suggests:
     rmarkdown,
     testthat (>= 3.0.0),
     tibble
-VignetteBuilder: 
+VignetteBuilder:
     knitr
 Config/Needs/website: tidyverse/tidytemplate
 Config/potools/style: explicit

--- a/R/glue.R
+++ b/R/glue.R
@@ -33,6 +33,7 @@
 #' )
 #'
 #' # `str_glue_data()` is useful in data pipelines
+#' # NOTE: this does not currently work with the `|>` base pipe
 #' mtcars %>% str_glue_data("{rownames(.)} has {hp} hp")
 str_glue <- function(..., .sep = "", .envir = parent.frame(), .trim = TRUE) {
   glue::glue(..., .sep = .sep, .envir = .envir, .trim = .trim)

--- a/R/replace.R
+++ b/R/replace.R
@@ -51,8 +51,8 @@
 #'
 #' # If you want to apply multiple patterns and replacements to the same
 #' # string, pass a named vector to pattern.
-#' fruits %>%
-#'   str_c(collapse = "---") %>%
+#' fruits |>
+#'   str_c(collapse = "---") |>
 #'   str_replace_all(c("one" = "1", "two" = "2", "three" = "3"))
 #'
 #' # Use a function for more sophisticated replacement. This example

--- a/README.Rmd
+++ b/README.Rmd
@@ -40,7 +40,7 @@ install.packages("stringr")
 
 ## Cheatsheet
 
-<a href="https://github.com/rstudio/cheatsheets/blob/main/strings.pdf"><img src="https://raw.githubusercontent.com/rstudio/cheatsheets/main/pngs/thumbnails/strings-cheatsheet-thumbs.png" width="630" height="242"/></a>  
+<a href="https://github.com/rstudio/cheatsheets/blob/main/strings.pdf"><img src="https://raw.githubusercontent.com/rstudio/cheatsheets/main/pngs/thumbnails/strings-cheatsheet-thumbs.png" width="630" height="242"/></a>
 
 ## Usage
 
@@ -48,7 +48,7 @@ All functions in stringr start with `str_` and take a vector of strings as the f
 
 ```{r}
 x <- c("why", "video", "cross", "extra", "deal", "authority")
-str_length(x) 
+str_length(x)
 str_c(x, collapse = ", ")
 str_sub(x, 1, 2)
 ```
@@ -66,7 +66,7 @@ There are seven main verbs that work with patterns:
     ```{r}
     str_detect(x, "[aeiou]")
     ```
-    
+
 *   `str_count(x, pattern)` counts the number of patterns:
     ```{r}
     str_count(x, "[aeiou]")
@@ -122,16 +122,16 @@ devtools::install_github("gadenbuie/regexplain")
 
 ## Compared to base R
 
-R provides a solid set of string operations, but because they have grown organically over time, they can be inconsistent and a little hard to learn. Additionally, they lag behind the string operations in other programming languages, so that some things that are easy to do in languages like Ruby or Python are rather hard to do in R. 
+R provides a solid set of string operations, but because they have grown organically over time, they can be inconsistent and a little hard to learn. Additionally, they lag behind the string operations in other programming languages, so that some things that are easy to do in languages like Ruby or Python are rather hard to do in R.
 
 * Uses consistent function and argument names. The first argument is always
   the vector of strings to modify, which makes stringr work particularly well
   in conjunction with the pipe:
-  
+
     ```{r}
-    letters %>%
-      .[1:10] %>% 
-      str_pad(3, "right") %>%
+    letters |>
+      .[1:10] |>
+      str_pad(3, "right") |>
       str_c(letters[2:11])
     ```
 
@@ -141,5 +141,5 @@ R provides a solid set of string operations, but because they have grown organic
 * Produces outputs than can easily be used as inputs. This includes ensuring
   that missing inputs result in missing outputs, and zero length inputs
   result in zero length outputs.
-  
+
 Learn more in `vignette("from-base")`

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ as the first argument:
 
 ``` r
 x <- c("why", "video", "cross", "extra", "deal", "authority")
-str_length(x) 
+str_length(x)
 #> [1] 3 5 5 5 4 9
 str_c(x, collapse = ", ")
 #> [1] "why, video, cross, extra, deal, authority"
@@ -124,11 +124,11 @@ There are seven main verbs that work with patterns:
   # extract the characters on either side of the vowel
   str_match(x, "(.)[aeiou](.)")
   #>      [,1]  [,2] [,3]
-  #> [1,] NA    NA   NA  
-  #> [2,] "vid" "v"  "d" 
-  #> [3,] "ros" "r"  "s" 
-  #> [4,] NA    NA   NA  
-  #> [5,] "dea" "d"  "a" 
+  #> [1,] NA    NA   NA
+  #> [2,] "vid" "v"  "d"
+  #> [3,] "ros" "r"  "s"
+  #> [4,] NA    NA   NA
+  #> [5,] "dea" "d"  "a"
   #> [6,] "aut" "a"  "t"
   ```
 
@@ -146,7 +146,7 @@ There are seven main verbs that work with patterns:
   str_split(c("a,b", "c,d,e"), ",")
   #> [[1]]
   #> [1] "a" "b"
-  #> 
+  #>
   #> [[2]]
   #> [1] "c" "d" "e"
   ```
@@ -188,9 +188,9 @@ languages like Ruby or Python are rather hard to do in R.
   particularly well in conjunction with the pipe:
 
   ``` r
-  letters %>%
-    .[1:10] %>% 
-    str_pad(3, "right") %>%
+  letters |>
+    .[1:10] |>
+    str_pad(3, "right") |>
     str_c(letters[2:11])
   #>  [1] "a  b" "b  c" "c  d" "d  e" "e  f" "f  g" "g  h" "h  i" "i  j" "j  k"
   ```

--- a/data-raw/samples.R
+++ b/data-raw/samples.R
@@ -2,10 +2,10 @@ words <- rcorpora::corpora("words/common")$commonWords
 fruit <- rcorpora::corpora("foods/fruits")$fruits
 
 html <- read_html("https://harvardsentences.com")
-html %>%
-  html_elements("li") %>%
-  html_text() %>%
-  iconv(to = "ASCII//translit") %>%
+html |>
+  html_elements("li") |>
+  html_text() |>
+  iconv(to = "ASCII//translit") |>
   writeLines("data-raw/harvard-sentences.txt")
 sentences <- readr::read_lines("data-raw/harvard-sentences.txt")
 

--- a/man/str_glue.Rd
+++ b/man/str_glue.Rd
@@ -64,5 +64,6 @@ str_glue(
 )
 
 # `str_glue_data()` is useful in data pipelines
+# NOTE: this does not currently work with the `|>` base pipe
 mtcars \%>\% str_glue_data("{rownames(.)} has {hp} hp")
 }

--- a/man/str_replace.Rd
+++ b/man/str_replace.Rd
@@ -65,8 +65,8 @@ str_replace(fruits, c("a", "e", "i"), "-")
 
 # If you want to apply multiple patterns and replacements to the same
 # string, pass a named vector to pattern.
-fruits \%>\%
-  str_c(collapse = "---") \%>\%
+fruits |>
+  str_c(collapse = "---") |>
   str_replace_all(c("one" = "1", "two" = "2", "three" = "3"))
 
 # Use a function for more sophisticated replacement. This example

--- a/tests/testthat/test-wrap.R
+++ b/tests/testthat/test-wrap.R
@@ -5,9 +5,9 @@ test_that("wrapping removes spaces", {
 })
 
 test_that("wrapping with width of 0 puts each word on own line", {
-  n_returns <- letters %>%
-    str_c(collapse = " ") %>%
-    str_wrap(0) %>%
+  n_returns <- letters |>
+    str_c(collapse = " ") |>
+    str_wrap(0) |>
     str_count("\n")
   expect_equal(n_returns, length(letters) - 1)
 })

--- a/vignettes/from-base.Rmd
+++ b/vignettes/from-base.Rmd
@@ -21,7 +21,7 @@ library(stringr)
 library(magrittr)
 ```
 
-This vignette compares stringr functions to their base R equivalents to help users transitioning from using base R to stringr. 
+This vignette compares stringr functions to their base R equivalents to help users transitioning from using base R to stringr.
 
 # Overall differences
 
@@ -57,15 +57,15 @@ data_stringr_base_diff <- tibble::tribble(
 )
 
 # create MD table, arranged alphabetically by stringr fn name
-data_stringr_base_diff %>%
+data_stringr_base_diff |>
   dplyr::mutate(dplyr::across(
       .cols = everything(),
       .fns = ~ paste0("`", .x, "`"))
-  ) %>%
-  dplyr::arrange(stringr) %>%
-  dplyr::rename(`base R` = base_r) %>%
-  gt::gt() %>%
-  gt::fmt_markdown(columns = everything()) %>%
+  ) |>
+  dplyr::arrange(stringr) |>
+  dplyr::rename(`base R` = base_r) |>
+  gt::gt() |>
+  gt::fmt_markdown(columns = everything()) |>
   gt::tab_options(column_labels.font.weight = "bold")
 ```
 
@@ -73,22 +73,22 @@ Overall the main differences between base R and stringr are:
 
 1.  stringr functions start with `str_` prefix; base R string functions have no
     consistent naming scheme.
-   
-1.  The order of inputs is usually different between base R and stringr. 
+
+1.  The order of inputs is usually different between base R and stringr.
     In base R, the `pattern` to match usually comes first; in stringr, the
-    `string` to manupulate always comes first. This makes stringr easier 
+    `string` to manupulate always comes first. This makes stringr easier
     to use in pipes, and with `lapply()` or `purrr::map()`.
-    
-1.  Functions in stringr tend to do less, where many of the string processing 
+
+1.  Functions in stringr tend to do less, where many of the string processing
     functions in base R have multiple purposes.
-    
+
 1.  The output and input of stringr functions has been carefully designed.
-    For example, the output of `str_locate()` can be fed directly into 
+    For example, the output of `str_locate()` can be fed directly into
     `str_sub()`; the same is not true of `regexpr()` and `substr()`.
-    
+
 1.  Base functions use arguments (like `perl`, `fixed`, and `ignore.case`)
     to control how the pattern is interpreted. To avoid dependence between
-    arguments, stringr instead uses helper functions (like `fixed()`, 
+    arguments, stringr instead uses helper functions (like `fixed()`,
     `regex()`, and `coll()`).
 
 Next we'll walk through each of the functions, noting the similarities and important differences. These examples are adapted from the stringr documentation and here they are contrasted with the analogous base R operations.
@@ -97,7 +97,7 @@ Next we'll walk through each of the functions, noting the similarities and impor
 
 ## `str_detect()`: Detect the presence or absence of a pattern in a string
 
-Suppose you want to know whether each word in a vector of fruit names contains an "a". 
+Suppose you want to know whether each word in a vector of fruit names contains an "a".
 
 ```{r}
 fruit <- c("apple", "banana", "pear", "pineapple")
@@ -109,11 +109,11 @@ grepl(pattern = "a", x = fruit)
 str_detect(fruit, pattern = "a")
 ```
 
-In base you would use `grepl()` (see the "l" and think logical) while in stringr you use `str_detect()` (see the verb "detect" and think of a yes/no action). 
+In base you would use `grepl()` (see the "l" and think logical) while in stringr you use `str_detect()` (see the verb "detect" and think of a yes/no action).
 
 ## `str_which()`: Find positions matching a pattern
 
-Now you want to identify the positions of the words in a vector of fruit names that contain an "a". 
+Now you want to identify the positions of the words in a vector of fruit names that contain an "a".
 
 ```{r}
 # base
@@ -123,14 +123,14 @@ grep(pattern = "a", x = fruit)
 str_which(fruit, pattern = "a")
 ```
 
-In base you would use `grep()` while in stringr you use `str_which()` (by analogy to `which()`). 
+In base you would use `grep()` while in stringr you use `str_which()` (by analogy to `which()`).
 
 ## `str_count()`: Count the number of matches in a string
 
 How many "a"s are in each fruit?
 
 ```{r}
-# base 
+# base
 loc <- gregexpr(pattern = "a", text = fruit, fixed = TRUE)
 sapply(loc, function(x) length(attr(x, "match.length")))
 
@@ -166,7 +166,7 @@ hw <- "Hadley Wickham"
 
 # base
 substr(hw, start = 1, stop = 6)
-substring(hw, first = 1) 
+substring(hw, first = 1)
 
 # stringr
 str_sub(hw, start = 1, end = 6)
@@ -174,7 +174,7 @@ str_sub(hw, start = 1)
 str_sub(hw, end = 6)
 ```
 
-In base you could use `substr()` or `substring()`. The former requires both a start and stop of the substring while the latter assumes the stop will be the end of the string. The stringr version, `str_sub()` has the same functionality, but also gives a default start value (the beginning of the string). Both the base and stringr functions have the same order of expected inputs. 
+In base you could use `substr()` or `substring()`. The former requires both a start and stop of the substring while the latter assumes the stop will be the end of the string. The stringr version, `str_sub()` has the same functionality, but also gives a default start value (the beginning of the string). Both the base and stringr functions have the same order of expected inputs.
 
 In stringr you can use negative numbers to index from the right-hand side string: -1 is the last letter, -2 is the second to last, and so on.
 
@@ -256,7 +256,7 @@ matches <- gregexpr(pattern = "[a-z]+", text = shopping_list) # words
 regmatches(shopping_list, m = matches)
 
 # stringr
-str_extract(shopping_list, pattern = "\\d+") 
+str_extract(shopping_list, pattern = "\\d+")
 str_extract_all(shopping_list, "[a-z]+")
 ```
 
@@ -300,7 +300,7 @@ There are some subtle differences between base and stringr here. `nchar()` requi
 #| error: true
 
 # base
-nchar(factor("abc")) 
+nchar(factor("abc"))
 ```
 
 ```{r}
@@ -320,7 +320,7 @@ str_length(x)
 
 ## `str_pad()`: Pad a string
 
-To pad a string to a certain width, use stringr's `str_pad()`. In base R you could use `sprintf()`, but unlike `str_pad()`, `sprintf()` has many other functionalities. 
+To pad a string to a certain width, use stringr's `str_pad()`. In base R you could use `sprintf()`, but unlike `str_pad()`, `sprintf()` has many other functionalities.
 
 ```{r}
 # base
@@ -375,7 +375,7 @@ str_squish("\n\nString with excess, trailing and leading white space\n\n")
 
 ## `str_wrap()`: Wrap strings into nicely formatted paragraphs
 
-`strwrap()` and `str_wrap()` use different algorithms. `str_wrap()` uses the famous [Knuth-Plass algorithm](http://litherum.blogspot.com/2015/07/knuth-plass-line-breaking-algorithm.html). 
+`strwrap()` and `str_wrap()` use different algorithms. `str_wrap()` uses the famous [Knuth-Plass algorithm](http://litherum.blogspot.com/2015/07/knuth-plass-line-breaking-algorithm.html).
 
 ```{r}
 gettysburg <- "Four score and seven years ago our fathers brought forth on this continent, a new nation, conceived in Liberty, and dedicated to the proposition that all men are created equal."
@@ -393,7 +393,7 @@ Note that `strwrap()` returns a character vector with one element for each line;
 
 ## `str_replace()`: Replace matched patterns in a string
 
-To replace certain patterns within a string, stringr provides the functions `str_replace()` and `str_replace_all()`. The base R equivalents are `sub()` and `gsub()`. Note the difference in default input order again. 
+To replace certain patterns within a string, stringr provides the functions `str_replace()` and `str_replace_all()`. The base R equivalents are `sub()` and `gsub()`. Note the difference in default input order again.
 
 ```{r}
 fruits <- c("apple", "banana", "pear", "pineapple")
@@ -502,7 +502,7 @@ anniversary <- as.Date("1991-10-12")
 
 # base
 sprintf(
-  "My name is %s my age next year is %s and my anniversary is %s.", 
+  "My name is %s my age next year is %s and my anniversary is %s.",
   name,
   age + 1,
   format(anniversary, "%A, %B %d, %Y")

--- a/vignettes/regular-expressions.Rmd
+++ b/vignettes/regular-expressions.Rmd
@@ -17,7 +17,7 @@ knitr::opts_chunk$set(
 library(stringr)
 ```
 
-Regular expressions are a concise and flexible tool for describing patterns in strings. This vignette describes the key features of stringr's regular expressions, as implemented by [stringi](https://github.com/gagolews/stringi). It is not a tutorial, so if you're unfamiliar regular expressions, I'd recommend starting at <https://r4ds.had.co.nz/strings.html>. If you want to master the details, I'd recommend reading the classic [_Mastering Regular Expressions_](https://www.amazon.com/Mastering-Regular-Expressions-Jeffrey-Friedl/dp/0596528124) by Jeffrey E. F. Friedl. 
+Regular expressions are a concise and flexible tool for describing patterns in strings. This vignette describes the key features of stringr's regular expressions, as implemented by [stringi](https://github.com/gagolews/stringi). It is not a tutorial, so if you're unfamiliar regular expressions, I'd recommend starting at <https://r4ds.had.co.nz/strings.html>. If you want to master the details, I'd recommend reading the classic [_Mastering Regular Expressions_](https://www.amazon.com/Mastering-Regular-Expressions-Jeffrey-Friedl/dp/0596528124) by Jeffrey E. F. Friedl.
 
 Regular expressions are the default pattern engine in stringr. That means when you use a pattern matching function with a bare string, it's equivalent to wrapping it in a call to `regex()`:
 
@@ -41,7 +41,7 @@ str_extract(x, "an")
 ```
 
 You can perform a case-insensitive match using `ignore_case = TRUE`:
-    
+
 ```{r}
 bananas <- c("banana", "Banana", "BANANA")
 str_detect(bananas, "banana")
@@ -63,7 +63,7 @@ str_detect("\nX\n", regex(".X.", dotall = TRUE))
 
 ## Escaping
 
-If "`.`" matches any character, how do you match a literal "`.`"? You need to use an "escape" to tell the regular expression you want to match it exactly, not use its special behaviour. Like strings, regexps use the backslash, `\`, to escape special behaviour. So to match an `.`, you need the regexp `\.`. Unfortunately this creates a problem. We use strings to represent regular expressions, and `\` is also used as an escape symbol in strings. So to create the regular expression `\.` we need the string `"\\."`. 
+If "`.`" matches any character, how do you match a literal "`.`"? You need to use an "escape" to tell the regular expression you want to match it exactly, not use its special behaviour. Like strings, regexps use the backslash, `\`, to escape special behaviour. So to match an `.`, you need the regexp `\.`. Unfortunately this creates a problem. We use strings to represent regular expressions, and `\` is also used as an escape symbol in strings. So to create the regular expression `\.` we need the string `"\\."`.
 
 ```{r}
 # To create the regular expression, we need \\
@@ -127,7 +127,7 @@ Similarly, you can specify many common control characters:
 
 * `\t`: horizontal tabulation (`\u0009`).
 
-* `\0ooo` match an octal character. 'ooo' is from one to three octal digits, 
+* `\0ooo` match an octal character. 'ooo' is from one to three octal digits,
   from 000 to 0377. The leading zero is required.
 
 (Many of these are only of historical interest and are only included here for the sake of completeness.)
@@ -135,7 +135,7 @@ Similarly, you can specify many common control characters:
 ## Matching multiple characters
 
 There are a number of patterns that match more than one character. You've already seen `.`, which matches any character (except a newline). A closely related operator is `\X`, which matches a __grapheme cluster__, a set of individual elements that form a single symbol. For example, one way of representing "á" is as the letter "a" plus an accent: `.` will match the component "a", while `\X` will match the complete symbol:
-    
+
 ```{r}
 x <- "a\u0301"
 str_extract(x, ".")
@@ -143,61 +143,61 @@ str_extract(x, "\\X")
 ```
 
 There are five other escaped pairs that match narrower classes of characters:
-   
-*   `\d`: matches any digit. The complement, `\D`, matches any character that 
+
+*   `\d`: matches any digit. The complement, `\D`, matches any character that
     is not a decimal digit.
 
     ```{r}
     str_extract_all("1 + 2 = 3", "\\d+")[[1]]
     ```
 
-    Technically, `\d` includes any character in the Unicode Category of Nd 
-    ("Number, Decimal Digit"), which also includes numeric symbols from other 
+    Technically, `\d` includes any character in the Unicode Category of Nd
+    ("Number, Decimal Digit"), which also includes numeric symbols from other
     languages:
-    
+
     ```{r}
     # Some Laotian numbers
     str_detect("១២៣", "\\d")
     ```
-    
-*   `\s`: matches any whitespace. This includes tabs, newlines, form feeds, 
-    and any character in the Unicode Z Category (which includes a variety of 
+
+*   `\s`: matches any whitespace. This includes tabs, newlines, form feeds,
+    and any character in the Unicode Z Category (which includes a variety of
     space characters and other separators.). The complement, `\S`, matches any
     non-whitespace character.
-    
+
     ```{r}
     (text <- "Some  \t badly\n\t\tspaced \f text")
     str_replace_all(text, "\\s+", " ")
     ```
 
 *   `\p{property name}` matches any character with specific unicode property,
-    like `\p{Uppercase}` or `\p{Diacritic}`. The complement, 
+    like `\p{Uppercase}` or `\p{Diacritic}`. The complement,
     `\P{property name}`, matches all characters without the property.
     A complete list of unicode properties can be found at
     <http://www.unicode.org/reports/tr44/#Property_Index>.
-    
+
     ```{r}
     (text <- c('"Double quotes"', "«Guillemet»", "“Fancy quotes”"))
     str_replace_all(text, "\\p{quotation mark}", "'")
     ```
 
-*   `\w` matches any "word" character, which includes alphabetic characters, 
+*   `\w` matches any "word" character, which includes alphabetic characters,
     marks and decimal numbers. The complement, `\W`, matches any non-word
     character.
-    
+
     ```{r}
     str_extract_all("Don't eat that!", "\\w+")[[1]]
     str_split("Don't eat that!", "\\W")[[1]]
     ```
-    
+
     Technically, `\w` also matches connector punctuation, `\u200c` (zero width
     connector), and `\u200d` (zero width joiner), but these are rarely seen in
     the wild.
 
-*   `\b` matches word boundaries, the transition between word and non-word 
+*   `\b` matches word boundaries, the transition between word and non-word
     characters. `\B` matches the opposite: boundaries that have either both
     word or non-word characters on either side.
-    
+
     ```{r}
     str_replace_all("The quick brown fox", "\\b", "_")
     str_replace_all("The quick brown fox", "\\B", "_")
@@ -206,7 +206,7 @@ There are five other escaped pairs that match narrower classes of characters:
 You can also create your own __character classes__ using `[]`:
 
 * `[abc]`: matches a, b, or c.
-* `[a-z]`: matches every character between a and z 
+* `[a-z]`: matches every character between a and z
    (in Unicode code point order).
 * `[^abc]`: matches anything except a, b, or c.
 * `[\^\-]`: matches `^` or `-`.
@@ -253,11 +253,11 @@ Parenthesis also define "groups" that you can refer to with __backreferences__, 
 
 ```{r}
 pattern <- "(..)\\1"
-fruit %>% 
+fruit |>
   str_subset(pattern)
 
-fruit %>% 
-  str_subset(pattern) %>% 
+fruit |>
+  str_subset(pattern) |>
   str_match(pattern)
 ```
 
@@ -274,7 +274,7 @@ This is most useful for more complex cases where you need to capture matches and
 
 By default, regular expressions will match any part of a string. It's often useful to __anchor__ the regular expression so that it matches from the start or end of the string:
 
-* `^` matches the start of string. 
+* `^` matches the start of string.
 * `$` matches the end of the string.
 
 ```{r}
@@ -287,7 +287,7 @@ To match a literal "$" or "^", you need to escape them, `\$`, and `\^`.
 
 For multiline strings, you can use `regex(multiline = TRUE)`. This changes the behaviour of `^` and `$`, and introduces three new operators:
 
-* `^` now matches the start of each line. 
+* `^` now matches the start of each line.
 
 * `$` now matches the end of each line.
 
@@ -295,7 +295,7 @@ For multiline strings, you can use `regex(multiline = TRUE)`. This changes the b
 
 * `\z` matches the end of the input.
 
-* `\Z` matches the end of the input, but before the final line terminator, 
+* `\Z` matches the end of the input, but before the final line terminator,
   if it exists.
 
 ```{r}
@@ -369,19 +369,19 @@ The atomic match fails because it matches A, and then the next character is a C 
 
 These assertions look ahead or behind the current match without "consuming" any characters (i.e. changing the input position).
 
-* `(?=...)`: positive look-ahead assertion. Matches if `...` matches at the 
+* `(?=...)`: positive look-ahead assertion. Matches if `...` matches at the
   current input.
-  
-* `(?!...)`: negative look-ahead assertion. Matches if `...` __does not__ 
+
+* `(?!...)`: negative look-ahead assertion. Matches if `...` __does not__
   match at the current input.
-  
-* `(?<=...)`: positive look-behind assertion. Matches if `...` matches text 
-  preceding the current position, with the last character of the match 
-  being the character just before the current position. Length must be bounded  
+
+* `(?<=...)`: positive look-behind assertion. Matches if `...` matches text
+  preceding the current position, with the last character of the match
+  being the character just before the current position. Length must be bounded
   (i.e. no `*` or `+`).
 
 * `(?<!...)`: negative look-behind assertion. Matches if `...` __does not__
-  match text preceding the current position. Length must be bounded  
+  match text preceding the current position. Length must be bounded
   (i.e. no `*` or `+`).
 
 These are useful when you want to check that a pattern exists, but you don't want to include it in the result:

--- a/vignettes/stringr.Rmd
+++ b/vignettes/stringr.Rmd
@@ -11,21 +11,21 @@ vignette: >
 #| include = FALSE
 library(stringr)
 knitr::opts_chunk$set(
-  comment = "#>", 
+  comment = "#>",
   collapse = TRUE
 )
 ```
 
-There are four main families of functions in stringr: 
+There are four main families of functions in stringr:
 
-1.  Character manipulation: these functions allow you to manipulate 
+1.  Character manipulation: these functions allow you to manipulate
     individual characters within the strings in character vectors.
-   
+
 1.  Whitespace tools to add, remove, and manipulate whitespace.
 
 1.  Locale sensitive operations whose operations will vary from locale
     to locale.
-    
+
 1.  Pattern matching functions. These recognise four engines of
     pattern description. The most common is regular expressions, but there
     are three other tools.
@@ -70,37 +70,37 @@ str_dup(x, c(2, 3))
 
 Three functions add, remove, or modify whitespace:
 
-1. `str_pad()` pads a string to a fixed length by adding extra whitespace on 
+1. `str_pad()` pads a string to a fixed length by adding extra whitespace on
     the left, right, or both sides.
-    
+
     ```{r}
     x <- c("abc", "defghi")
     str_pad(x, 10) # default pads on left
     str_pad(x, 10, "both")
     ```
-    
+
     (You can pad with other characters by using the `pad` argument.)
-    
+
     `str_pad()` will never make a string shorter:
-    
+
     ```{r}
     str_pad(x, 4)
     ```
-    
+
     So if you want to ensure that all strings are the same length (often useful
     for print methods), combine `str_pad()` and `str_trunc()`:
-    
+
     ```{r}
     x <- c("Short", "This is a long string")
-    
-    x %>% 
-      str_trunc(10) %>% 
+
+    x |>
+      str_trunc(10) |>
       str_pad(10, "right")
     ```
 
-1.  The opposite of `str_pad()` is `str_trim()`, which removes leading and 
+1.  The opposite of `str_pad()` is `str_trim()`, which removes leading and
     trailing whitespace:
-    
+
     ```{r}
     x <- c("  a   ", "b   ",  "   c")
     str_trim(x)
@@ -108,9 +108,9 @@ Three functions add, remove, or modify whitespace:
     ```
 
 1.  You can use `str_wrap()` to modify existing whitespace in order to wrap
-    a paragraph of text, such that the length of each line is as similar as 
-    possible. 
-    
+    a paragraph of text, such that the length of each line is as similar as
+    possible.
+
     ```{r}
     jabberwocky <- str_c(
       "`Twas brillig, and the slithy toves ",
@@ -158,19 +158,19 @@ Each pattern matching function has the same first two arguments, a character vec
 
 ```{r}
 strings <- c(
-  "apple", 
-  "219 733 8965", 
-  "329-293-8753", 
+  "apple",
+  "219 733 8965",
+  "329-293-8753",
   "Work: 579-499-7527; Home: 543.355.3679"
 )
 phone <- "([2-9][0-9]{2})[- .]([0-9]{3})[- .]([0-9]{4})"
 ```
 
--   `str_detect()` detects the presence or absence of a pattern and returns a 
+-   `str_detect()` detects the presence or absence of a pattern and returns a
     logical vector (similar to `grepl()`). `str_subset()` returns the elements
-    of a character vector that match a regular expression (similar to `grep()` 
+    of a character vector that match a regular expression (similar to `grep()`
     with `value = TRUE`)`.
-    
+
     ```{r}
     # Which strings contain phone numbers?
     str_detect(strings, phone)
@@ -184,8 +184,8 @@ phone <- "([2-9][0-9]{2})[- .]([0-9]{3})[- .]([0-9]{4})"
     str_count(strings, phone)
     ```
 
--   `str_locate()` locates the **first** position of a pattern and returns a numeric 
-    matrix with columns start and end. `str_locate_all()` locates all matches, 
+-   `str_locate()` locates the **first** position of a pattern and returns a numeric
+    matrix with columns start and end. `str_locate_all()` locates all matches,
     returning a list of numeric matrices. Similar to `regexpr()` and `gregexpr()`.
 
     ```{r}
@@ -194,8 +194,8 @@ phone <- "([2-9][0-9]{2})[- .]([0-9]{3})[- .]([0-9]{4})"
     str_locate_all(strings, phone)
     ```
 
--   `str_extract()` extracts text corresponding to the **first** match, returning a 
-    character vector. `str_extract_all()` extracts all matches and returns a 
+-   `str_extract()` extracts text corresponding to the **first** match, returning a
+    character vector. `str_extract_all()` extracts all matches and returns a
     list of character vectors.
 
     ```{r}
@@ -205,10 +205,10 @@ phone <- "([2-9][0-9]{2})[- .]([0-9]{3})[- .]([0-9]{4})"
     str_extract_all(strings, phone, simplify = TRUE)
     ```
 
--   `str_match()` extracts capture groups formed by `()` from the **first** match. 
-    It returns a character matrix with one column for the complete match and 
-    one column for each group. `str_match_all()` extracts capture groups from 
-    all matches and returns a list of character matrices. Similar to 
+-   `str_match()` extracts capture groups formed by `()` from the **first** match.
+    It returns a character matrix with one column for the complete match and
+    one column for each group. `str_match_all()` extracts capture groups from
+    all matches and returns a list of character matrices. Similar to
     `regmatches()`.
 
     ```{r}
@@ -218,7 +218,7 @@ phone <- "([2-9][0-9]{2})[- .]([0-9]{3})[- .]([0-9]{4})"
     ```
 
 -   `str_replace()` replaces the **first** matched pattern and returns a character
-    vector. `str_replace_all()` replaces all matches. Similar to `sub()` and 
+    vector. `str_replace_all()` replaces all matches. Similar to `sub()` and
     `gsub()`.
 
     ```{r}
@@ -226,10 +226,10 @@ phone <- "([2-9][0-9]{2})[- .]([0-9]{3})[- .]([0-9]{4})"
     str_replace_all(strings, phone, "XXX-XXX-XXXX")
     ```
 
--   `str_split_fixed()` splits a string into a **fixed** number of pieces based 
-    on a pattern and returns a character matrix. `str_split()` splits a string 
+-   `str_split_fixed()` splits a string into a **fixed** number of pieces based
+    on a pattern and returns a character matrix. `str_split()` splits a string
     into a **variable** number of pieces and returns a list of character vectors.
-    
+
     ```{r}
     str_split("a-b-c", "-")
     str_split_fixed("a-b-c", "-", n = 2)
@@ -240,8 +240,8 @@ phone <- "([2-9][0-9]{2})[- .]([0-9]{3})[- .]([0-9]{4})"
 There are four main engines that stringr can use to describe patterns:
 
 * Regular expressions, the default, as shown above, and described in
-  `vignette("regular-expressions")`. 
-  
+  `vignette("regular-expressions")`.
+
 * Fixed bytewise matching, with `fixed()`.
 
 * Locale-sensitive character matching, with `coll()`
@@ -259,7 +259,7 @@ c(a1, a2)
 a1 == a2
 ```
 
-They render identically, but because they're defined differently, 
+They render identically, but because they're defined differently,
 `fixed()` doesn't find a match. Instead, you can use `coll()`, explained
 below, to respect human character comparison rules:
 
@@ -267,9 +267,9 @@ below, to respect human character comparison rules:
 str_detect(a1, fixed(a2))
 str_detect(a1, coll(a2))
 ```
-    
+
 #### Collation search
-    
+
 `coll(x)` looks for a match to `x` using human-language **coll**ation rules, and is particularly important if you want to do case insensitive matching. Collation rules differ around the world, so you'll also need to supply a `locale` parameter.
 
 ```{r}


### PR DESCRIPTION
Note: One `str_glue()` example still needs to use magrittr,
because this does not work with the base R placeholder:
```r
mtcars |> str_glue_data("{rownames(_)} has {hp} hp")
```